### PR TITLE
Add barrier clipping removal for IW4 TU6

### DIFF
--- a/src/game/iw4/mp_tu6/components/pm.cpp
+++ b/src/game/iw4/mp_tu6/components/pm.cpp
@@ -1,53 +1,103 @@
 #include "pch.h"
 #include "pm.h"
 
+// bg_removeBarriers
+int MASK_PLAYER_CLIP = 0x10000;
+int MASK_BARRIER_CLIP = 0x400;
+
 namespace iw4
 {
-namespace mp_tu6
-{
-namespace
-{
-dvar_t *bg_rocketJump = nullptr;
-dvar_t *bg_rocketJumpScale = nullptr;
-
-Detour Weapon_RocketLauncher_Fire_Detour;
-
-gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, unsigned int weaponIndex, double spread, weaponParms *wp,
-                                           weaponParms *gunVel, lockonFireParms *lockParms,
-                                           lockonFireParms *magicBullet)
-{
-    const auto result = Weapon_RocketLauncher_Fire_Detour.GetOriginal<decltype(Weapon_RocketLauncher_Fire)>()(
-        ent, weaponIndex, spread, wp, gunVel, lockParms, magicBullet);
-
-    if (ent->client && bg_rocketJump && bg_rocketJumpScale && bg_rocketJump->current.enabled)
+    namespace mp_tu6
     {
-        const auto scale = bg_rocketJumpScale->current.value;
-        ent->client->ps.velocity[0] += (0.0f - wp->forward[0]) * scale;
-        ent->client->ps.velocity[1] += (0.0f - wp->forward[1]) * scale;
-        ent->client->ps.velocity[2] += (0.0f - wp->forward[2]) * scale;
-    }
+        namespace
+        {
+            dvar_t* bg_rocketJump = nullptr;
+            dvar_t* bg_rocketJumpScale = nullptr;
+            dvar_t* bg_removeBarriers = nullptr;
 
-    return result;
-}
+            Detour Weapon_RocketLauncher_Fire_Detour;
+            Detour PmoveSingle_Detour;
+            Detour PM_CheckLadderMove_Detour;
 
-} // namespace
+            gentity_s* Weapon_RocketLauncher_Fire_Hook(gentity_s* ent, unsigned int weaponIndex, double spread, weaponParms* wp,
+                weaponParms* gunVel, lockonFireParms* lockParms,
+                lockonFireParms* magicBullet)
+            {
+                const auto result = Weapon_RocketLauncher_Fire_Detour.GetOriginal<decltype(Weapon_RocketLauncher_Fire)>()(
+                    ent, weaponIndex, spread, wp, gunVel, lockParms, magicBullet);
 
-void pm::OnDvarInit()
-{
-    bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
-    bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
-                                            "The scale applied to the pushback force of a rocket");
-}
+                if (ent->client && bg_rocketJump && bg_rocketJumpScale && bg_rocketJump->current.enabled)
+                {
+                    const auto scale = bg_rocketJumpScale->current.value;
+                    ent->client->ps.velocity[0] += (0.0f - wp->forward[0]) * scale;
+                    ent->client->ps.velocity[1] += (0.0f - wp->forward[1]) * scale;
+                    ent->client->ps.velocity[2] += (0.0f - wp->forward[2]) * scale;
+                }
 
-pm::pm()
-{
-    Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
-    Weapon_RocketLauncher_Fire_Detour.Install();
-}
+                return result;
+            }
 
-pm::~pm()
-{
-    Weapon_RocketLauncher_Fire_Detour.Remove();
-}
-} // namespace mp_tu6
+            // bg_removeBarriers
+            void PmoveSingle_Hook(pmove_t* pm)
+            {
+                if (bg_removeBarriers && bg_removeBarriers->current.enabled)
+                {
+                    if (pm != nullptr && (pm->ps->pm_flags & PMF_LADDER) == 0)
+                    {
+                        pm->tracemask &= ~MASK_PLAYER_CLIP;
+                        pm->tracemask |= MASK_BARRIER_CLIP;
+                    }
+                }
+
+                PmoveSingle_Detour.GetOriginal<decltype(PmoveSingle)>()(pm);
+            }
+
+            void PM_CheckLadderMove_Hook(pmove_t* pm, pml_t* pml)
+            {
+                const auto fix_ladder_movement = (bg_removeBarriers && bg_removeBarriers->current.enabled && pm != nullptr);
+
+                if (fix_ladder_movement)
+                {
+                    pm->tracemask |= MASK_PLAYER_CLIP;
+                }
+
+                PM_CheckLadderMove_Detour.GetOriginal<decltype(PM_CheckLadderMove)>()(pm, pml);
+
+                if (fix_ladder_movement && (pm->ps->pm_flags & PMF_LADDER) == 0)
+                {
+                    pm->tracemask &= ~MASK_PLAYER_CLIP;
+                }
+            }
+
+        } // namespace
+
+        void pm::OnDvarInit()
+        {
+            bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
+            bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
+                "The scale applied to the pushback force of a rocket");
+            // bg_removeBarriers
+            bg_removeBarriers = Dvar_RegisterBool("bg_removeBarriers", false, DVAR_CODINFO, "Remove player collision with out of bound barriers");
+        }
+
+        pm::pm()
+        {
+            Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
+            Weapon_RocketLauncher_Fire_Detour.Install();
+
+            // bg_removeBarriers
+            PmoveSingle_Detour = Detour(PmoveSingle, PmoveSingle_Hook);
+            PmoveSingle_Detour.Install();
+
+            PM_CheckLadderMove_Detour = Detour(PM_CheckLadderMove, PM_CheckLadderMove_Hook);
+            PM_CheckLadderMove_Detour.Install();
+        }
+
+        pm::~pm()
+        {
+            Weapon_RocketLauncher_Fire_Detour.Remove();
+            PmoveSingle_Detour.Remove();
+            PM_CheckLadderMove_Detour.Remove();
+        }
+    } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/structs.h
+++ b/src/game/iw4/mp_tu6/structs.h
@@ -5,2117 +5,2212 @@
 
 namespace iw4
 {
-namespace mp_tu6
-{
-
-struct internal_state;
-
-struct Sys_File
-{
-    void *handle;
-    int startOffset;
-};
-
-struct DBFile
-{
-    Sys_File handle;
-    char name[64];
-};
-
-struct XBlock
-{
-    unsigned __int8 *data;
-    unsigned int size;
-};
-
-struct XZoneMemory
-{
-    XBlock blocks[6];
-};
-
-struct XZone
-{
-    DBFile file;
-    int flags;
-    int allocType;
-    XZoneMemory mem;
-};
-
-struct _OVERLAPPED
-{
-    unsigned int Internal;
-    unsigned int InternalHigh;
-    unsigned int Offset;
-    unsigned int OffsetHigh;
-    void *hEvent;
-};
-
-struct z_stream_s
-{
-    unsigned __int8 *next_in;
-    unsigned int avail_in;
-    unsigned int total_in;
-    unsigned __int8 *next_out;
-    unsigned int avail_out;
-    unsigned int total_out;
-    char *msg;
-    internal_state *state;
-    unsigned __int8 *(__fastcall *zalloc)(unsigned __int8 *, unsigned int, unsigned int);
-    void(__fastcall *zfree)(unsigned __int8 *, unsigned __int8 *);
-    unsigned __int8 *opaque;
-    int data_type;
-};
-
-struct DB_LoadData
-{
-    DBFile *file;
-    int outstandingRead;
-    unsigned __int8 *fileBuffer;
-    unsigned int readSize;
-    unsigned int completedReadSize;
-    unsigned int offset;
-    unsigned __int8 *start_in;
-    _OVERLAPPED overlapped;
-    unsigned int readError;
-    z_stream_s stream;
-    unsigned int lookaheadReadSize;
-    unsigned int lookaheadOffset;
-    unsigned int lookaheadClearAvailIn;
-};
-
-union DvarValue
-{
-    bool enabled;
-    int integer;
-    unsigned int unsignedInt;
-    float value;
-    float vector[4];
-    const char *string;
-    unsigned __int8 color[4];
-};
-
-struct DvarLimits_enumeration
-{
-    int stringCount;
-    const char **strings;
-};
-
-struct DvarLimits_integer
-{
-    int min;
-    int max;
-};
-
-struct DvarLimits_value
-{
-    float min;
-    float max;
-};
-
-struct DvarLimits_vector
-{
-    float min;
-    float max;
-};
-
-union DvarLimits
-{
-    DvarLimits_enumeration enumeration;
-    DvarLimits_integer integer;
-    DvarLimits_value value;
-    DvarLimits_vector vector;
-};
-
-enum DvarFlags : std::uint16_t
-{
-    DVAR_FLAG_SERVERINFO = 0x10,
-};
-
-enum svscmd_type : __int32
-{
-    SV_CMD_CAN_IGNORE = 0x0,
-    SV_CMD_RELIABLE = 0x1,
-};
-
-struct dvar_t
-{
-    const char *name;
-    const char *description;
-    unsigned __int16 flags;
-    unsigned __int8 type;
-    bool modified;
-    DvarValue current;
-    DvarValue latched;
-    DvarValue reset;
-    DvarLimits domain;
-    dvar_t *hashNext;
-};
-
-enum ViewLockTypes : __int32
-{
-    PLAYERVIEWLOCK_NONE = 0x0,
-    PLAYERVIEWLOCK_FULL = 0x1,
-    PLAYERVIEWLOCK_WEAPONJITTER = 0x2,
-    PLAYERVIEWLOCKCOUNT = 0x3,
-};
-
-struct SprintState
-{
-    int sprintButtonUpRequired;
-    int sprintDelay;
-    int lastSprintStart;
-    int lastSprintEnd;
-    int sprintStartMaxLength;
-};
-
-struct MantleState
-{
-    float yaw;
-    int timer;
-    int transIndex;
-    int flags;
-};
-
-struct PlayerActiveWeaponState
-{
-    int weapAnim;
-    int weaponTime;
-    int weaponDelay;
-    int weaponRestrictKickTime;
-    int weaponState;
-    int weapHandFlags;
-    unsigned int weaponShotCount;
-};
-
-struct PlayerEquippedWeaponState
-{
-    bool usedBefore;
-    bool dualWielding;
-    unsigned __int8 weaponModel;
-    bool needsRechamber[2];
-};
-
-enum OffhandClass : __int32
-{
-    OFFHAND_CLASS_NONE = 0x0,
-    OFFHAND_CLASS_FRAG_GRENADE = 0x1,
-    OFFHAND_CLASS_SMOKE_GRENADE = 0x2,
-    OFFHAND_CLASS_FLASH_GRENADE = 0x3,
-    OFFHAND_CLASS_THROWINGKNIFE = 0x4,
-    OFFHAND_CLASS_OTHER = 0x5,
-    OFFHAND_CLASS_COUNT = 0x6,
-};
-
-enum PlayerHandIndex : __int32
-{
-    WEAPON_HAND_RIGHT = 0x0,
-    WEAPON_HAND_LEFT = 0x1,
-    NUM_WEAPON_HANDS = 0x2,
-    WEAPON_HAND_DEFAULT = 0x0,
-};
-
-enum team_t : __int32
-{
-    TEAM_FREE = 0x0,
-    TEAM_AXIS = 0x1,
-    TEAM_ALLIES = 0x2,
-    TEAM_SPECTATOR = 0x3,
-    TEAM_NUM_TEAMS = 0x4,
-};
-
-struct GlobalAmmo
-{
-    int ammoType;
-    int ammoCount;
-};
-
-struct ClipAmmo
-{
-    int clipIndex;
-    int ammoCount[2];
-};
-
-struct PlayerWeaponCommonState
-{
-    int offHandIndex;
-    OffhandClass offhandPrimary;
-    OffhandClass offhandSecondary;
-    unsigned int weapon;
-    unsigned int primaryWeaponForAltMode;
-    int weapFlags;
-    float fWeaponPosFrac;
-    float aimSpreadScale;
-    int adsDelayTime;
-    int spreadOverride;
-    int spreadOverrideState;
-    PlayerHandIndex lastWeaponHand;
-    GlobalAmmo ammoNotInClip[15];
-    ClipAmmo ammoInClip[15];
-    int weapLockFlags;
-    int weapLockedEntnum;
-    float weapLockedPos[3];
-    int weaponIdleTime;
-};
-static_assert(offsetof(PlayerWeaponCommonState, fWeaponPosFrac) == 0x18, "");
-
-enum ActionSlotType : __int32
-{
-    ACTIONSLOTTYPE_DONOTHING = 0x0,
-    ACTIONSLOTTYPE_SPECIFYWEAPON = 0x1,
-    ACTIONSLOTTYPE_ALTWEAPONTOGGLE = 0x2,
-    ACTIONSLOTTYPE_NIGHTVISION = 0x3,
-    ACTIONSLOTTYPECOUNT = 0x4,
-};
-
-struct ActionSlotParam_SpecifyWeapon
-{
-    unsigned int index;
-};
-
-struct ActionSlotParam
-{
-    ActionSlotParam_SpecifyWeapon specifyWeapon;
-};
-
-enum objectiveState_t : __int32
-{
-    OBJST_EMPTY = 0x0,
-    OBJST_ACTIVE = 0x1,
-    OBJST_INVISIBLE = 0x2,
-    OBJST_DONE = 0x3,
-    OBJST_CURRENT = 0x4,
-    OBJST_FAILED = 0x5,
-    OBJST_NUMSTATES = 0x6,
-};
-
-struct objective_t
-{
-    objectiveState_t state;
-    float origin[3];
-    int entNum;
-    int teamNum;
-    int icon;
-};
-
-enum he_type_t : __int32
-{
-    HE_TYPE_FREE = 0x0,
-    HE_TYPE_TEXT = 0x1,
-    HE_TYPE_VALUE = 0x2,
-    HE_TYPE_PLAYERNAME = 0x3,
-    HE_TYPE_MAPNAME = 0x4,
-    HE_TYPE_GAMETYPE = 0x5,
-    HE_TYPE_MATERIAL = 0x6,
-    HE_TYPE_TIMER_DOWN = 0x7,
-    HE_TYPE_TIMER_UP = 0x8,
-    HE_TYPE_TENTHS_TIMER_DOWN = 0x9,
-    HE_TYPE_TENTHS_TIMER_UP = 0xA,
-    HE_TYPE_CLOCK_DOWN = 0xB,
-    HE_TYPE_CLOCK_UP = 0xC,
-    HE_TYPE_WAYPOINT = 0xD,
-    HE_TYPE_COUNT = 0xE,
-};
-
-struct $0D0CB43DF22755AD856C77DD3F304010
-{
-    unsigned __int8 r;
-    unsigned __int8 g;
-    unsigned __int8 b;
-    unsigned __int8 a;
-};
-
-union hudelem_color_t
-{
-    $0D0CB43DF22755AD856C77DD3F304010 __s0;
-    int rgba;
-};
-
-struct hudelem_s
-{
-    he_type_t type;
-    float x;
-    float y;
-    float z;
-    int targetEntNum;
-    float fontScale;
-    float fromFontScale;
-    int fontScaleStartTime;
-    int fontScaleTime;
-    int font;
-    int alignOrg;
-    int alignScreen;
-    hudelem_color_t color;
-    hudelem_color_t fromColor;
-    int fadeStartTime;
-    int fadeTime;
-    int label;
-    int width;
-    int height;
-    int materialIndex;
-    int fromWidth;
-    int fromHeight;
-    int scaleStartTime;
-    int scaleTime;
-    float fromX;
-    float fromY;
-    int fromAlignOrg;
-    int fromAlignScreen;
-    int moveStartTime;
-    int moveTime;
-    int time;
-    int duration;
-    float value;
-    int text;
-    float sort;
-    hudelem_color_t glowColor;
-    int fxBirthTime;
-    int fxLetterTime;
-    int fxDecayStartTime;
-    int fxDecayDuration;
-    int soundID;
-    int flags;
-};
-
-struct playerState_s_hud
-{
-    hudelem_s current[31];
-    hudelem_s archival[31];
-};
-
-struct __declspec(align(128)) playerState_s
-{
-    int commandTime;
-    int pm_type;
-    int pm_time;
-    int pm_flags;
-    int otherFlags;
-    int linkFlags;
-    int bobCycle;
-    float origin[3];
-    float velocity[3];
-    int grenadeTimeLeft;
-    int throwbackGrenadeOwner;
-    int throwbackGrenadeTimeLeft;
-    unsigned int throwbackWeaponIndex;
-    int remoteEyesEnt;
-    int remoteEyesTagname;
-    int remoteControlEnt;
-    int foliageSoundTime;
-    int gravity;
-    float leanf;
-    int speed;
-    float delta_angles[3];
-    int groundEntityNum;
-    float vLadderVec[3];
-    int jumpTime;
-    float jumpOriginZ;
-    int legsTimer;
-    int legsAnim;
-    int torsoTimer;
-    int torsoAnim;
-    int legsAnimDuration;
-    int torsoAnimDuration;
-    int damageTimer;
-    int damageDuration;
-    int flinchYawAnim;
-    int corpseIndex;
-    int movementDir;
-    int eFlags;
-    int eventSequence;
-    int events[4];
-    unsigned int eventParms[4];
-    int oldEventSequence;
-    int unpredictableEventSequence;
-    int unpredictableEventSequenceOld;
-    int unpredictableEvents[4];
-    unsigned int unpredictableEventParms[4];
-    int clientNum;
-    int viewmodelIndex;
-    float viewangles[3];
-    int viewHeightTarget;
-    float viewHeightCurrent;
-    int viewHeightLerpTime;
-    int viewHeightLerpTarget;
-    int viewHeightLerpDown;
-    float viewAngleClampBase[2];
-    float viewAngleClampRange[2];
-    int damageEvent;
-    int damageYaw;
-    int damagePitch;
-    int damageCount;
-    int damageFlags;
-    int stats[4];
-    float proneDirection;
-    float proneDirectionPitch;
-    float proneTorsoPitch;
-    ViewLockTypes viewlocked;
-    int viewlocked_entNum;
-    float linkAngles[3];
-    float linkWeaponAngles[3];
-    int linkWeaponEnt;
-    int loopSound;
-    int cursorHint;
-    int cursorHintString;
-    int cursorHintEntIndex;
-    int cursorHintDualWield;
-    int iCompassPlayerInfo;
-    int radarEnabled;
-    int radarBlocked;
-    int radarMode;
-    int locationSelectionInfo;
-    SprintState sprintState;
-    float holdBreathScale;
-    int holdBreathTimer;
-    float moveSpeedScaleMultiplier;
-    MantleState mantleState;
-    PlayerActiveWeaponState weapState[2];
-    unsigned int weaponsEquipped[15];
-    PlayerEquippedWeaponState weapEquippedData[15];
-    PlayerWeaponCommonState weapCommon;
-    float meleeChargeYaw;
-    int meleeChargeDist;
-    int meleeChargeTime;
-    unsigned int perks[2];
-    unsigned int perkSlots[8];
-    ActionSlotType actionSlotType[4];
-    ActionSlotParam actionSlotParam[4];
-    int weaponHudIconOverrides[6];
-    int animScriptedType;
-    int shellshockIndex;
-    int shellshockTime;
-    int shellshockDuration;
-    float dofNearStart;
-    float dofNearEnd;
-    float dofFarStart;
-    float dofFarEnd;
-    float dofNearBlur;
-    float dofFarBlur;
-    float dofViewmodelStart;
-    float dofViewmodelEnd;
-    objective_t objective[32];
-    int deltaTime;
-    int killCamEntity;
-    int killCamLookAtEntity;
-    int killCamClientNum;
-    playerState_s_hud hud;
-    unsigned int partBits[5];
-    int recoilScale;
-    int diveDirection;
-    int stunTime;
-};
-
-static_assert(sizeof(playerState_s) == 12672, "");
-static_assert(offsetof(playerState_s, velocity) == 40, "");
-static_assert(offsetof(playerState_s, delta_angles) == 96, "");
-
-struct gclient_s;
-struct Turret;
-struct Vehicle;
-struct tagInfo_s;
-
-enum trType_t : __int32
-{
-    TR_STATIONARY = 0x0,
-    TR_INTERPOLATE = 0x1,
-    TR_LINEAR = 0x2,
-    TR_LINEAR_STOP = 0x3,
-    TR_SINE = 0x4,
-    TR_GRAVITY = 0x5,
-    TR_LOW_GRAVITY = 0x6,
-    TR_ACCELERATE = 0x7,
-    TR_DECELERATE = 0x8,
-    TR_PHYSICS = 0x9,
-    TR_FIRST_RAGDOLL = 0xA,
-    TR_RAGDOLL = 0xA,
-    TR_RAGDOLL_GRAVITY = 0xB,
-    TR_RAGDOLL_INTERPOLATE = 0xC,
-    TR_LAST_RAGDOLL = 0xC,
-    NUM_TRTYPES = 0xD,
-};
-
-struct trajectory_t
-{
-    trType_t trType;
-    int trTime;
-    int trDuration;
-    float trBase[3];
-    float trDelta[3];
-};
-
-struct LerpEntityStateTurret
-{
-    float gunAngles[3];
-    int lastBarrelRotChangeTime;
-    int lastBarrelRotChangeRate;
-    int lastHeatChangeLevel;
-    int lastHeatChangeTime;
-    bool isBarrelRotating;
-    bool isOverheat;
-    bool isHeatingUp;
-    bool isBeingCarried;
-};
-
-struct LerpEntityStateLoopFx
-{
-    float cullDist;
-    int period;
-};
-
-struct LerpEntityStatePrimaryLight
-{
-    unsigned __int8 colorAndExp[4];
-    float intensity;
-    float radius;
-    float cosHalfFovOuter;
-    float cosHalfFovInner;
-};
-
-struct LerpEntityStatePlayer
-{
-    float leanf;
-    int movementDir;
-    float torsoPitch;
-    float waistPitch;
-    unsigned int offhandWeapon;
-    int lastSpawnTime;
-};
-
-struct LerpEntityStateVehicle
-{
-    unsigned int indices;
-    unsigned int flags;
-    float bodyPitch;
-    float bodyRoll;
-    float steerYaw;
-    float gunPitch;
-    float gunYaw;
-    int playerIndex;
-    int pad;
-};
-
-struct LerpEntityStatePlane
-{
-    int ownerNum;
-    int enemyIcon;
-    int friendIcon;
-};
-
-enum MissileFlightMode : __int32
-{
-    MISSILEFLIGHTMODE_TOP = 0x0,
-    MISSILEFLIGHTMODE_DIRECT = 0x1,
-    MISSILEFLIGHTMODE_COUNT = 0x2,
-};
-
-struct LerpEntityStateMissile
-{
-    int launchTime;
-    MissileFlightMode flightMode;
-};
-
-struct LerpEntityStateSoundBlend
-{
-    float lerp;
-};
-
-struct LerpEntityStateBulletHit
-{
-    float start[3];
-};
-
-struct LerpEntityStateEarthquake
-{
-    float scale;
-    float radius;
-    int duration;
-};
-
-struct LerpEntityStateCustomExplode
-{
-    int startTime;
-};
-
-struct LerpEntityStateExplosion
-{
-    float innerRadius;
-    float outerRadius;
-    float magnitude;
-};
-
-struct LerpEntityStateExplosionJolt
-{
-    float innerRadius;
-    float outerRadius;
-    float impulse[3];
-};
-
-struct LerpEntityStatePhysicsJitter
-{
-    float innerRadius;
-    float outerRadius;
-    float minDisplacement;
-    float maxDisplacement;
-};
-
-struct LerpEntityStateRadiusDamage
-{
-    float range;
-    int damageMin;
-    int damageMax;
-};
-
-struct LerpEntityStateScriptMover
-{
-    int entToTakeMarksFrom;
-    int xModelIndex;
-    int animIndex;
-    int animTime;
-};
-
-struct LerpEntityStateAnonymous
-{
-    int data[9];
-};
-
-union LerpEntityStateTypeUnion
-{
-    LerpEntityStateTurret turret;
-    LerpEntityStateLoopFx loopFx;
-    LerpEntityStatePrimaryLight primaryLight;
-    LerpEntityStatePlayer player;
-    LerpEntityStateVehicle vehicle;
-    LerpEntityStatePlane plane;
-    LerpEntityStateMissile missile;
-    LerpEntityStateSoundBlend soundBlend;
-    LerpEntityStateBulletHit bulletHit;
-    LerpEntityStateEarthquake earthquake;
-    LerpEntityStateCustomExplode customExplode;
-    LerpEntityStateExplosion explosion;
-    LerpEntityStateExplosionJolt explosionJolt;
-    LerpEntityStatePhysicsJitter physicsJitter;
-    LerpEntityStateRadiusDamage radiusDamage;
-    LerpEntityStateScriptMover scriptMover;
-    LerpEntityStateAnonymous anonymous;
-};
-
-struct LerpEntityState
-{
-    int eFlags;
-    trajectory_t pos;
-    trajectory_t apos;
-    LerpEntityStateTypeUnion u;
-};
-
-union entityState_s_index
-{
-    int brushModel;
-    int triggerModel;
-    int item;
-    int xmodel;
-    int primaryLight;
-};
-
-struct entityState_s_wes
-{
-    unsigned __int16 weapon;
-    unsigned __int16 primaryWeapon;
-};
-
-union entityState_s_un1
-{
-    int eventParm2;
-    int hintString;
-    int fxId;
-    int helicopterStage;
-};
-
-union entityState_s_un2
-{
-    int hintType;
-    int vehicleXModel;
-    int actorFlags;
-    unsigned __int8 weaponModel;
-};
-
-struct clientLinkInfo_t
-{
-    unsigned __int8 flags;
-    unsigned __int8 tagName;
-    __int16 parentId;
-};
-
-struct entityState_s
-{
-    int number;
-    int eType;
-    LerpEntityState lerp;
-    int time2;
-    int otherEntityNum;
-    int attackerEntityNum;
-    int groundEntityNum;
-    int loopSound;
-    int surfType;
-    entityState_s_index index;
-    int clientNum;
-    int iHeadIcon;
-    int iHeadIconTeam;
-    int solid;
-    unsigned int eventParm;
-    int eventSequence;
-    int events[4];
-    unsigned int eventParms[4];
-    entityState_s_wes wes;
-    int legsAnim;
-    int torsoAnim;
-    entityState_s_un1 un1;
-    entityState_s_un2 un2;
-    clientLinkInfo_t clientLinkInfo;
-    unsigned int partBits[5];
-    int clientMask[1];
-    unsigned int pad[1];
-};
-
-struct EntHandle
-{
-    unsigned __int16 number;
-    unsigned __int16 infoIndex;
-};
-
-struct Bounds
-{
-    float midPoint[3];
-    float halfSize[3];
-};
-
-struct entityShared_t
-{
-    unsigned __int8 isLinked;
-    unsigned __int8 modelType;
-    unsigned __int8 svFlags;
-    unsigned __int8 isInUse;
-    Bounds box;
-    int contents;
-    Bounds absBox;
-    float currentOrigin[3];
-    float currentAngles[3];
-    EntHandle ownerNum;
-    int eventTime;
-};
-
-struct __declspec(align(4)) item_ent_t
-{
-    int ammoCount;
-    int clipAmmoCount[2];
-    int index;
-    bool dualWieldItem;
-};
-
-struct spawner_ent_t
-{
-    int team;
-    int timestamp;
-    int index;
-};
-
-struct __declspec(align(4)) trigger_ent_t
-{
-    int threshold;
-    int accumulate;
-    int timestamp;
-    int singleUserEntIndex;
-    bool requireLookAt;
-};
-
-struct mover_positions_t
-{
-    float decelTime;
-    float speed;
-    float midTime;
-    float pos1[3];
-    float pos2[3];
-    float pos3[3];
-};
-
-struct mover_slidedata_t
-{
-    Bounds bounds;
-    float velocity[3];
-};
-
-struct mover_ent_t
-{
-    union
+    namespace mp_tu6
     {
-        mover_positions_t pos;
-        mover_slidedata_t slide;
-    } ___u0;
-    mover_positions_t angle;
-};
-
-struct corpse_ent_t
-{
-    int deathAnimStartTime;
-};
-
-struct missile_fields_grenade
-{
-    float wobbleCycle;
-    float curve;
-};
-
-enum MissileStage : __int32
-{
-    MISSILESTAGE_SOFTLAUNCH = 0x0,
-    MISSILESTAGE_ASCENT = 0x1,
-    MISSILESTAGE_DESCENT = 0x2,
-};
-
-struct missile_fields_nonGrenade
-{
-    float curvature[3];
-    float targetEntOffset[3];
-    float targetPos[3];
-    float launchOrigin[3];
-    MissileStage stage;
-};
-
-struct missile_ent_t
-{
-    float time;
-    int timeOfBirth;
-    float travelDist;
-    float surfaceNormal[3];
-    team_t team;
-    int flags;
-    int antilagTimeOffset;
-    union
-    {
-        missile_fields_grenade grenade;
-        missile_fields_nonGrenade nonGrenade;
-    } ___u7;
-};
-
-struct blend_ent_t
-{
-    float pos[3];
-    float vel[3];
-    float viewQuat[4];
-    bool changed;
-    float accelTime;
-    float decelTime;
-    float startTime;
-    float totalTime;
-};
-
-enum entityFlag_t : uint32_t
-{
-    FL_GODMODE = 0x1,
-    FL_DEMI_GODMODE = 0x2,
-    FL_NOTARGET = 0x4,
-    FL_NO_KNOCKBACK = 0x8,
-    FL_NO_RADIUS_DAMAGE = 0x10,
-    FL_SUPPORTS_LINKTO = 0x1000,
-    FL_NO_AUTO_ANIM_UPDATE = 0x2000,
-    FL_GRENADE_TOUCH_DAMAGE = 0x4000,
-    FL_STABLE_MISSILES = 0x20000,
-    FL_REPEAT_ANIM_UPDATE = 0x40000,
-    FL_VEHICLE_TARGET = 0x80000,
-    FL_GROUND_ENT = 0x100000,
-    FL_CURSOR_HINT = 0x200000,
-    FL_MISSILE_ATTRACTOR = 0x800000,
-    FL_WEAPON_BEING_GRABBED = 0x1000000,
-    FL_DELETE = 0x2000000,
-    FL_BOUNCE = 0x4000000,
-    FL_MOVER_SLIDE = 0x8000000,
-};
-
-enum clientFlag_t : uint32_t
-{
-    CF_NOCLIP = 1u << 0,
-    CF_UFO = 1u << 1,
-    CF_FROZEN = 1u << 2,
-    CF_DISABLE_USABILITY = 1u << 3,
-    CF_NO_KNOCKBACK = 1u << 4,
-};
-
-struct gentity_s
-{
-    entityState_s s;
-    entityShared_t r;
-    gclient_s *client;
-    Turret *turret;
-    Vehicle *vehicle;
-    int physObjId;
-    unsigned __int16 model;
-    unsigned __int8 physicsObject;
-    unsigned __int8 takedamage;
-    unsigned __int8 active;
-    unsigned __int8 handler;
-    unsigned __int8 team;
-    bool freeAfterEvent;
-    __int16 padding_short;
-    unsigned __int16 classname;
-    unsigned __int16 script_classname;
-    unsigned __int16 script_linkName;
-    unsigned __int16 target;
-    unsigned __int16 targetname;
-    unsigned int attachIgnoreCollision;
-    int spawnflags;
-    int flags;
-    int eventTime;
-    int clipmask;
-    int processedFrame;
-    EntHandle parent;
-    int nextthink;
-    int health;
-    int maxHealth;
-    int damage;
-    int count;
-    union
-    {
-        item_ent_t item[2];
-        spawner_ent_t spawner;
-        trigger_ent_t trigger;
-        mover_ent_t mover;
-        corpse_ent_t corpse;
-        missile_ent_t missile;
-        blend_ent_t blend;
-    } ___u31;
-    EntHandle missileTargetEnt;
-    EntHandle remoteControlledOwner;
-    tagInfo_s *tagInfo;
-    gentity_s *tagChildren;
-    unsigned __int16 attachModelNames[19];
-    unsigned __int16 attachTagNames[19];
-    int useCount;
-    gentity_s *nextFree;
-    int birthTime;
-    int padding[3];
-};
-static_assert(sizeof(gentity_s) == 640, "");
-static_assert(offsetof(gentity_s, client) == 344, "");
-static_assert(offsetof(gentity_s, flags) == 0x184, "");
-
-struct sentient_s;
-struct actor_s;
-
-struct level_locals_t
-{
-    gclient_s *clients;
-    gentity_s *gentities;
-    int num_entities;
-    gentity_s *firstFreeEnt;
-    gentity_s *lastFreeEnt;
-    sentient_s *sentients;
-    actor_s *actors;
-    Vehicle *vehicles;
-    Turret *turrets;
-    int initializing;
-    int clientIsSpawning;
-    char pad_2C[0x3A4 - 0x2C];
-    int maxclients;
-};
-static_assert(offsetof(level_locals_t, clients) == 0x0, "");
-static_assert(offsetof(level_locals_t, gentities) == 0x4, "");
-static_assert(offsetof(level_locals_t, num_entities) == 0x8, "");
-static_assert(offsetof(level_locals_t, maxclients) == 0x3A4, "");
-
-enum weapInventoryType_t
-{
-    WEAPINVENTORY_PRIMARY = 0x0,
-    WEAPINVENTORY_OFFHAND = 0x1,
-    WEAPINVENTORY_ITEM = 0x2,
-    WEAPINVENTORY_ALTMODE = 0x3,
-    WEAPINVENTORY_EXCLUSIVE = 0x4,
-    WEAPINVENTORY_SCAVENGER = 0x5,
-    WEAPINVENTORYCOUNT = 0x6,
-};
-
-struct WeaponDef
-{
-    char pad[0x38];
-    weapInventoryType_t inventoryType;
-};
-static_assert(offsetof(WeaponDef, inventoryType) == 0x38, "");
-
-struct WeaponCompleteDef
-{
-    const char *szInternalName;
-    WeaponDef *weapDef;
-    char pad[0x38];
-    int altWeaponIndex;
-};
-static_assert(offsetof(WeaponCompleteDef, weapDef) == 0x4, "");
-static_assert(offsetof(WeaponCompleteDef, altWeaponIndex) == 0x40, "");
-
-struct weaponParms
-{
-    float forward[3];
-    float right[3];
-    float up[3];
-    float muzzleTrace[3];
-    float gunForward[3];
-    unsigned int weaponIndex;
-    const struct WeaponDef *weapDef;
-    const struct WeaponCompleteDef *weapCompleteDef;
-};
-static_assert(sizeof(weaponParms) == 0x48, "");
-
-struct weaponState_t;
-struct viewState_t;
-
-struct scr_entref_t
-{
-    unsigned __int16 entnum;
-    unsigned __int16 classnum;
-};
-
-enum ClassNum : __int32
-{
-    CLASS_NUM_ENTITY = 0x0,
-    CLASS_NUM_HUDELEM = 0x1,
-    CLASS_NUM_PATHNODE = 0x2,
-    CLASS_NUM_VEHICLENODE = 0x3,
-    CLASS_NUM_VEHTRACK_SEGMENT = 0x4,
-    CLASS_NUM_FXENTITY = 0x5,
-    CLASS_NUM_COUNT = 0x6,
-};
-
-struct cmd_function_s
-{
-    cmd_function_s *next;
-    const char *name;
-    const char *autoCompleteDir;
-    const char *autoCompleteExt;
-    void (*function)();
-};
-
-enum usercmdButtonBits
-{
-    CMD_BUTTON_ATTACK = 1 << 0,
-    CMD_BUTTON_SPRINT = 1 << 1,
-    CMD_BUTTON_MELEE = 1 << 2,
-    CMD_BUTTON_ACTIVATE = 1 << 3,
-    CMD_BUTTON_RELOAD = 1 << 4,
-    CMD_BUTTON_USE_RELOAD = 1 << 5,
-    CMD_BUTTON_LEAN_LEFT = 1 << 6,
-    CMD_BUTTON_LEAN_RIGHT = 1 << 7,
-    CMD_BUTTON_PRONE = 1 << 8,
-    CMD_BUTTON_CROUCH = 1 << 9,
-    CMD_BUTTON_UP = 1 << 10,
-    CMD_BUTTON_ADS = 1 << 11,
-    CMD_BUTTON_DOWN = 1 << 12,
-    CMD_BUTTON_BREATH = 1 << 13,
-    CMD_BUTTON_FRAG = 1 << 14,
-    CMD_BUTTON_OFFHAND_SECONDARY = 1 << 15,
-    CMD_BUTTON_THROW = 1 << 19,
-    CMD_BUTTON_REMOTE = 1 << 20,
-};
-static_assert(sizeof(usercmdButtonBits) == 4, "");
-
-struct __declspec(align(4)) usercmd_s
-{
-    int serverTime;
-    int buttons;
-    int angles[3];
-    unsigned __int16 weapon;
-    unsigned __int16 primaryWeaponForAltMode;
-    unsigned __int16 offHandIndex;
-    char forwardmove;
-    char rightmove;
-    float meleeChargeYaw;
-    unsigned __int8 meleeChargeDist;
-    char selectedLoc[2];
-    unsigned __int8 selectedLocAngle;
-    char remoteControlAngles[2];
-};
-static_assert(sizeof(usercmd_s) == 0x28, "");
-static_assert(offsetof(usercmd_s, serverTime) == 0x0, "");
-static_assert(offsetof(usercmd_s, buttons) == 0x4, "");
-static_assert(offsetof(usercmd_s, angles) == 0x8, "");
-static_assert(offsetof(usercmd_s, weapon) == 0x14, "");
-static_assert(offsetof(usercmd_s, primaryWeaponForAltMode) == 0x16, "");
-static_assert(offsetof(usercmd_s, offHandIndex) == 0x18, "");
-static_assert(offsetof(usercmd_s, forwardmove) == 0x1A, "");
-static_assert(offsetof(usercmd_s, rightmove) == 0x1B, "");
-static_assert(offsetof(usercmd_s, meleeChargeYaw) == 0x1C, "");
-static_assert(offsetof(usercmd_s, meleeChargeDist) == 0x20, "");
-static_assert(offsetof(usercmd_s, remoteControlAngles) == 0x24, "");
-
-enum netadrtype_t : __int32
-{
-    NA_BOT = 0x0,
-};
-
-struct netadr_t
-{
-    netadrtype_t type;
-};
-static_assert(offsetof(netadr_t, type) == 0x0, "");
-
-struct netchan_t
-{
-    char pad_0[0x4];
-    int outgoingSequence;
-    char pad_8[0xC];
-    netadr_t remoteAddress;
-};
-static_assert(offsetof(netchan_t, outgoingSequence) == 0x4, "");
-static_assert(offsetof(netchan_t, remoteAddress) == 0x14, "");
-
-struct clientHeader_t
-{
-    int state;
-    char pad_4[0x4];
-    int deltaMessage;
-    char pad_C[0x8];
-    netchan_t netchan;
-};
-static_assert(offsetof(clientHeader_t, state) == 0x0, "");
-static_assert(offsetof(clientHeader_t, deltaMessage) == 0x8, "");
-static_assert(offsetof(clientHeader_t, netchan) == 0x14, "");
-static_assert(offsetof(clientHeader_t, netchan) + offsetof(netchan_t, outgoingSequence) == 0x18, "");
-static_assert(offsetof(clientHeader_t, netchan) + offsetof(netchan_t, remoteAddress) + offsetof(netadr_t, type) == 0x28,
-              "");
-
-struct client_t
-{
-    clientHeader_t header;
-    const char *dropReason;
-    char pad_30[0x650 - 0x30];
-    char userinfo[1024];
-    char pad_A50[0x21294 - 0xA50];
-    gentity_s *gentity;
-    char name[32];
-    char clanAbbrev[5];
-    char pad_212BD[0x212D4 - 0x212BD];
-    int ping;
-    char pad_212D8[0x97F80 - 0x212D8];
-};
-static_assert(sizeof(client_t) == 0x97F80, "");
-static_assert(offsetof(client_t, header) == 0x0, "");
-static_assert(offsetof(client_t, header) + offsetof(clientHeader_t, deltaMessage) == 0x8, "");
-static_assert(offsetof(client_t, dropReason) == 0x2C, "");
-static_assert(offsetof(client_t, userinfo) == 0x650, "");
-static_assert(offsetof(client_t, gentity) == 0x21294, "");
-static_assert(offsetof(client_t, name) == 0x21298, "");
-static_assert(offsetof(client_t, clanAbbrev) == 0x212B8, "");
-static_assert(offsetof(client_t, ping) == 0x212D4, "");
-
-struct serverStaticHeader_t
-{
-    int time;
-    int timeResidual;
-    int clientCount;
-    client_t *clients;
-};
-static_assert(offsetof(serverStaticHeader_t, time) == 0x0, "");
-static_assert(offsetof(serverStaticHeader_t, clientCount) == 0x8, "");
-static_assert(offsetof(serverStaticHeader_t, clients) == 0xC, "");
-
-struct __declspec(align(128)) clSnapshot_t
-{
-    playerState_s ps;
-    int valid;
-    int snapFlags;
-    int serverTime;
-    int messageNum;
-    int deltaNum;
-    int ping;
-    int cmdNum;
-    int numEntities;
-    int numClients;
-    int parseEntitiesIndex;
-    int parseClientsIndex;
-    int serverCommandNum;
-};
-
-enum StanceState : __int32
-{
-    CL_STANCE_STAND = 0x0,
-    CL_STANCE_CROUCH = 0x1,
-    CL_STANCE_PRONE = 0x2,
-};
-
-struct ClientArchiveData
-{
-    int serverTime;
-    float origin[3];
-    float velocity[3];
-    int bobCycle;
-    int movementDir;
-};
-
-struct outPacket_t
-{
-    int p_cmdNumber;
-    int p_serverTime;
-    int p_realtime;
-};
-
-struct clientState_s
-{
-    int clientIndex;
-    team_t team;
-    int modelindex;
-    int dualWielding;
-    int riotShieldNext;
-    int attachModelIndex[6];
-    int attachTagIndex[6];
-    char name[32];
-    float maxSprintTimeMultiplier;
-    int rank;
-    int prestige;
-    unsigned int perks[2];
-    int diveState;
-    int voiceConnectivityBits;
-    char clanAbbrev[8];
-    unsigned int playerCardIcon;
-    unsigned int playerCardTitle;
-    unsigned int playerCardNameplate;
-};
-
-enum sessionState_t : __int32
-{
-    SESS_STATE_PLAYING = 0x0,
-    SESS_STATE_DEAD = 0x1,
-    SESS_STATE_SPECTATOR = 0x2,
-    SESS_STATE_INTERMISSION = 0x3,
-};
-
-enum clientConnected_t : __int32
-{
-    CON_DISCONNECTED = 0x0,
-    CON_CONNECTING = 0x1,
-    CON_CONNECTED = 0x2,
-};
-
-struct playerTeamState_t
-{
-    int location;
-};
-
-struct clientSession_t
-{
-    sessionState_t sessionState;
-    int forceSpectatorClient;
-    int killCamEntity;
-    int killCamLookAtEntity;
-    int status_icon;
-    int archiveTime;
-    int score;
-    int deaths;
-    int kills;
-    int assists;
-    unsigned __int16 scriptPersId;
-    clientConnected_t connected;
-    usercmd_s cmd;
-    usercmd_s oldcmd;
-    int localClient;
-    int predictItemPickup;
-    char newnetname[32];
-    int maxHealth;
-    int enterTime;
-    playerTeamState_t teamState;
-    int voteCount;
-    int teamVoteCount;
-    float moveSpeedScaleMultiplier;
-    int viewmodelIndex;
-    int noSpectate;
-    int teamInfo;
-    clientState_s cs;
-    int psOffsetTime;
-    int hasRadar;
-    int isRadarBlocked;
-    int radarMode;
-    int weaponHudIconOverrides[6];
-    unsigned int unusableEntFlags[64];
-    float spectateDefaultPos[3];
-    float spectateDefaultAngles[3];
-};
-static_assert(sizeof(clientSession_t) == 0x2A0, "");
-static_assert(offsetof(clientSession_t, connected) == 0x2C, "");
-static_assert(offsetof(clientSession_t, cmd) == 0x30, "");
-static_assert(offsetof(clientSession_t, cs) == 0xCC, "");
-
-struct viewClamp
-{
-    float start[2];
-    float current[2];
-    float goal[2];
-};
-
-struct viewClampState
-{
-    viewClamp min;
-    viewClamp max;
-    float accelTime;
-    float decelTime;
-    float totalTime;
-    float startTime;
-};
-
-enum hintType_t : __int32
-{
-    HINT_NONE = 0x0,
-    HINT_NOICON = 0x1,
-    HINT_ACTIVATE = 0x2,
-    HINT_HEALTH = 0x3,
-    HINT_FRIENDLY = 0x4,
-    FIRST_WEAPON_HINT = 0x5,
-    LAST_WEAPON_HINT = 0x4B4,
-    HINT_NUM_HINTS = 0x4B5,
-};
-
-struct gclient_s
-{
-    playerState_s ps;
-    clientSession_t sess;
-    int flags;
-    int spectatorClient;
-    int lastCmdTime;
-    int mpviewer;
-    int buttons;
-    int oldbuttons;
-    int latched_buttons;
-    int buttonsSinceLastFrame;
-    float oldOrigin[3];
-    float fGunPitch;
-    float fGunYaw;
-    int damage_blood;
-    int damage_stun;
-    float damage_from[3];
-    int damage_fromWorld;
-    int accurateCount;
-    int accuracy_shots;
-    int accuracy_hits;
-    int inactivityTime;
-    int inactivityWarning;
-    int lastVoiceTime;
-    int switchTeamTime;
-    float currentAimSpreadScale;
-    float prevLinkedInvQuat[4];
-    bool prevLinkAnglesSet;
-    bool link_rotationMovesEyePos;
-    bool link_doCollision;
-    bool link_useTagAnglesForViewAngles;
-    float linkAnglesFrac;
-    viewClampState link_viewClamp;
-    gentity_s *persistantPowerup;
-    int portalID;
-    int dropWeaponTime;
-    int sniperRifleFiredTime;
-    float sniperRifleMuzzleYaw;
-    int PCSpecialPickedUpCount;
-    EntHandle useHoldEntity;
-    int useHoldTime;
-    int useButtonDone;
-    int iLastCompassPlayerInfoEnt;
-    int compassPingTime;
-    int damageTime;
-    float v_dmg_roll;
-    float v_dmg_pitch;
-    float baseAngles[3];
-    float baseOrigin[3];
-    float swayViewAngles[3];
-    float swayOffset[3];
-    float swayAngles[3];
-    float recoilAngles[3];
-    float recoilSpeed[3];
-    float fLastIdleFactor;
-    int weapIdleTime;
-    int lastServerTime;
-    unsigned int lastWeapon;
-    bool previouslyFiring;
-    bool previouslyFiringLeftHand;
-    bool previouslyUsingNightVision;
-    bool previouslySprinting;
-    int visionDuration[5];
-    char visionName[5][64];
-    int lastStand;
-    int lastStandTime;
-    int hudElemLastAssignedSoundID;
-    float lockedTargetOffset[3];
-    int attachShieldTagName;
-    hintType_t hintForcedType;
-    int hintForcedString;
-    int padding;
-};
-static_assert(sizeof(gclient_s) == 0x3700, "");
-static_assert(offsetof(gclient_s, ps) == 0x0, "");
-static_assert(offsetof(gclient_s, sess) == 0x3180, "");
-static_assert(offsetof(gclient_s, flags) == 0x3420, "");
-static_assert(offsetof(gclient_s, buttons) == 0x3430, "");
-static_assert(offsetof(gclient_s, attachShieldTagName) == 0x36F0, "");
-static_assert(offsetof(gclient_s, hintForcedType) == 0x36F4, "");
-static_assert(offsetof(gclient_s, hintForcedString) == 0x36F8, "");
-static_assert(offsetof(gclient_s, padding) == 0x36FC, "");
-
-struct __declspec(align(128)) clientActive_t
-{
-    bool usingAds;
-    int timeoutcount;
-    clSnapshot_t snap;
-    bool alwaysFalse;
-    int serverTime;
-    int oldServerTime;
-    int oldFrameServerTime;
-    int serverTimeDelta;
-    int oldSnapServerTime;
-    int extrapolatedSnapshot;
-    int newSnapshots;
-    int serverId;
-    char mapname[64];
-    int parseEntitiesIndex;
-    int parseClientsIndex;
-    int mouseDx[2];
-    int mouseDy[2];
-    int mouseIndex;
-    bool stanceHeld;
-    StanceState stance;
-    StanceState stancePosition;
-    int stanceTime;
-    int cgameUserCmdWeapon;
-    int cgameUserCmdOffHandIndex;
-    float cgameFOVSensitivityScale;
-    float cgameMaxPitchSpeed;
-    float cgameMaxYawSpeed;
-    float cgameKickAngles[3];
-    float cgameOrigin[3];
-    float cgameVelocity[3];
-    int cgameBobCycle;
-    int cgameMovementDir;
-    int cgameExtraButtons;
-    int cgamePredictedDataServerTime;
-    float viewangles[3];
-    usercmd_s cmds[128];
-    int cmdNumber;
-    ClientArchiveData clientArchive[256];
-    int clientArchiveIndex;
-    int packetBackupCount;
-    int packetBackupMask;
-    int parseEntitiesCount;
-    int parseClientsCount;
-    outPacket_t *outPackets;
-    clSnapshot_t *snapshots;
-    entityState_s *parseEntities;
-    clientState_s *parseClients;
-    int corruptedTranslationFile;
-    char translationVersion[256];
-};
-static_assert(sizeof(clientActive_t) == 27904, "");
-
-enum connstate_t : __int32
-{
-    CA_DISCONNECTED = 0x0,
-    CA_CINEMATIC = 0x1,
-    CA_LOGO = 0x2,
-    CA_CONNECTING = 0x3,
-    CA_CHALLENGING = 0x4,
-    CA_CONNECTED = 0x5,
-    CA_SENDINGSTATS = 0x6,
-    CA_LOADING = 0x7,
-    CA_PRIMED = 0x8,
-    CA_ACTIVE = 0x9,
-};
-
-struct clientUIActive_t
-{
-    bool active;
-    bool isRunning;
-    bool cgameInitialized;        // 0x002 - v7[2] = 1 in retail
-    bool cgameInitCalled;         // 0x003 - v7[3] = 1 in retail
-    char pad_4[2876];             // 0x004 - padding to reach keyCatchers
-    int keyCatchers;              // 0xB40 - dword_825A6458[804*a1] in retail
-    int displayHUDWithKeycatchUI; // 0xB44
-    connstate_t connectionState;  // 0xB48 - dword_825A6460[804*a1] in retail
-    char pad_B4C[324];            // 0xB4C - padding to reach struct size
-};
-
-static_assert(sizeof(clientUIActive_t) == 0xC90, "");                    // 3216 bytes
-static_assert(offsetof(clientUIActive_t, keyCatchers) == 0xB40, "");     // 2880 bytes
-static_assert(offsetof(clientUIActive_t, connectionState) == 0xB48, ""); // 2888 bytes
-
-enum keyNum_t : __int32
-{
-    K_NONE = 0x0,
-    K_TAB = 0x9,
-    K_ENTER = 0xD,
-    K_ESCAPE = 0x1B,
-    K_SPACE = 0x20,
-    K_BACKSPACE = 0x7F,
-    K_CAPSLOCK = 0x97,
-    K_PAUSE = 0x99,
-    K_UPARROW = 0x9A,
-    K_DOWNARROW = 0x9B,
-    K_LEFTARROW = 0x9C,
-    K_RIGHTARROW = 0x9D,
-    K_ALT = 0x9E,
-    K_CTRL = 0x9F,
-    K_SHIFT = 0xA0,
-    K_INS = 0xA1,
-    K_DEL = 0xA2,
-    K_PGDN = 0xA3,
-    K_PGUP = 0xA4,
-    K_HOME = 0xA5,
-    K_END = 0xA6,
-    K_F1 = 0xA7,
-    K_F2 = 0xA8,
-    K_F3 = 0xA9,
-    K_F4 = 0xAA,
-    K_F5 = 0xAB,
-    K_F6 = 0xAC,
-    K_F7 = 0xAD,
-    K_F8 = 0xAE,
-    K_F9 = 0xAF,
-    K_F10 = 0xB0,
-    K_F11 = 0xB1,
-    K_F12 = 0xB2,
-    K_KP_HOME = 0xB6,
-    K_KP_UPARROW = 0xB7,
-    K_KP_PGUP = 0xB8,
-    K_KP_LEFTARROW = 0xB9,
-    K_KP_5 = 0xBA,
-    K_KP_RIGHTARROW = 0xBB,
-    K_KP_END = 0xBC,
-    K_KP_DOWNARROW = 0xBD,
-    K_KP_PGDN = 0xBE,
-    K_KP_ENTER = 0xBF,
-    K_KP_INS = 0xC0,
-    K_KP_DEL = 0xC1,
-    K_KP_SLASH = 0xC2,
-    K_KP_MINUS = 0xC3,
-    K_KP_PLUS = 0xC4,
-    K_KP_NUMLOCK = 0xC5,
-    K_KP_STAR = 0xC6,
-    K_KP_EQUALS = 0xC7,
-};
-
-struct field_t
-{
-    int cursor;
-    int scroll;
-    int drawWidth;
-    int widthInPixels;
-    float charHeight;
-    int fixedSize;
-    char buffer[256];
-};
-
-static_assert(sizeof(field_t) == 0x118, "");
-static_assert(offsetof(field_t, buffer) == 0x18, "");
-
-enum LocSelInputState : __int32
-{
-    LOC_SEL_INPUT_NONE = 0x0,
-    LOC_SEL_INPUT_CONFIRM = 0x1,
-    LOC_SEL_INPUT_CANCEL = 0x2,
-};
-
-struct KeyState
-{
-    int down;
-    int repeats;
-    const char *binding;
-};
-
-static_assert(sizeof(KeyState) == 0xC, "");
-
-struct PlayerKeyState
-{
-    field_t chatField;
-    int chat_team;
-    int overstrikeMode;
-    int anyKeyDown;
-    KeyState keys[256];
-    LocSelInputState locSelInputState;
-};
-
-static_assert(sizeof(PlayerKeyState) == 0xD28, "");
-static_assert(offsetof(PlayerKeyState, keys) == 0x124, "");
-
-struct MessageLine
-{
-    int messageIndex;
-    int textBufPos;
-    int textBufSize;
-    int typingStartTime;
-    int lastTypingSoundTime;
-    int flags;
-};
-
-static_assert(sizeof(MessageLine) == 0x18, "");
-
-struct Message
-{
-    int startTime;
-    int endTime;
-};
-
-static_assert(sizeof(Message) == 0x8, "");
-
-struct MessageWindow
-{
-    MessageLine *lines;
-    Message *messages;
-    char *circularTextBuffer;
-    int textBufSize;
-    int lineCount;
-    int padding;
-    int scrollTime;
-    int fadeIn;
-    int fadeOut;
-    int textBufPos;
-    int firstLineIndex;
-    int activeLineCount;
-    int messageIndex;
-};
-
-static_assert(sizeof(MessageWindow) == 0x34, "");
-
-struct MessageBuffer
-{
-    char gamemsgText[4][2048];
-    MessageWindow gamemsgWindows[4];
-    MessageLine gamemsgLines[4][12];
-    Message gamemsgMessages[4][12];
-    char miniconText[4096];
-    MessageWindow miniconWindow;
-    MessageLine miniconLines[100];
-    Message miniconMessages[100];
-    char errorText[1024];
-    MessageWindow errorWindow;
-    MessageLine errorLines[5];
-    Message errorMessages[5];
-};
-
-static_assert(sizeof(MessageBuffer) == 0x4858, "");
-static_assert(offsetof(MessageBuffer, miniconText) == 0x26D0, "");
-static_assert(offsetof(MessageBuffer, errorText) == 0x4384, "");
-
-struct Console
-{
-    MessageWindow consoleWindow;
-    MessageLine consoleLines[1024];
-    Message consoleMessages[1024];
-    char consoleText[32768];
-    char textTempLine[512];
-    unsigned int lineOffset;
-    int displayLineOffset;
-    int prevChannel;
-    bool outputVisible;
-    int fontHeight;
-    int visibleLineCount;
-    int visiblePixelWidth;
-    float screenMin[2];
-    float screenMax[2];
-    MessageBuffer messageBuffer[4];
-    float color[4];
-};
-
-static_assert(sizeof(Console) == 0x223D0, "");
-static_assert(offsetof(Console, consoleLines) == 0x34, "");
-static_assert(offsetof(Console, consoleMessages) == 0x6034, "");
-static_assert(offsetof(Console, consoleText) == 0x8034, "");
-static_assert(offsetof(Console, textTempLine) == 0x10034, "");
-static_assert(offsetof(Console, lineOffset) == 0x10234, "");
-static_assert(offsetof(Console, displayLineOffset) == 0x10238, "");
-static_assert(offsetof(Console, outputVisible) == 0x10240, "");
-static_assert(offsetof(Console, fontHeight) == 0x10244, "");
-static_assert(offsetof(Console, visibleLineCount) == 0x10248, "");
-static_assert(offsetof(Console, messageBuffer) == 0x10260, "");
-static_assert(offsetof(Console, color) == 0x223C0, "");
-
-struct __declspec(align(128)) cg_s
-{
-    playerState_s predictedPlayerState;
-    char padding[1027200];
-};
-static_assert(sizeof(cg_s) == 1039872, "");
-
-typedef void (*BuiltinFunction)();
-typedef void (*BuiltinMethod)(scr_entref_t);
-
-enum scr_builtin_type_t : __int32
-{
-    BUILTIN_ANY = 0x0,
-    BUILTIN_DEVELOPER_ONLY = 0x1,
-};
-static_assert(sizeof(scr_builtin_type_t) == 4, "");
-
-struct BuiltinFunctionDef
-{
-    const char *actionString;
-    BuiltinFunction actionFunc;
-    scr_builtin_type_t type;
-};
-
-struct BuiltinMethodDef
-{
-    const char *actionString;
-    BuiltinMethod actionFunc;
-    scr_builtin_type_t type;
-};
-
-enum fieldtype_t : __int32
-{
-    F_INT = 0x0,
-    F_SHORT = 0x1,
-    F_BYTE = 0x2,
-    F_FLOAT = 0x3,
-    F_CSTRING = 0x4,
-    F_STRING = 0x5,
-    F_VECTOR = 0x6,
-    F_ENTITY = 0x7,
-    F_ENTHANDLE = 0x8,
-    F_ANGLES_YAW = 0x9,
-    F_OBJECT = 0xA,
-    F_MODEL = 0xB,
-};
-
-struct client_fields_s
-{
-    const char *name;
-    int ofs;
-    fieldtype_t type;
-    void (*setter)(gclient_s *, const client_fields_s *);
-    void (*getter)(gclient_s *, const client_fields_s *);
-};
-
-struct Font_s;
-struct Material;
-
-struct CachedAssets_t
-{
-    Material *scrollBarArrowUp;
-    Material *scrollBarArrowDown;
-    Material *scrollBarArrowLeft;
-    Material *scrollBarArrowRight;
-    Material *scrollBar;
-    Material *scrollBarThumb;
-    Material *sliderBar;
-    Material *sliderThumb;
-    Material *whiteMaterial;
-    Material *cursor;
-    Material *textDecodeCharacters;
-    Material *textDecodeCharactersGlow;
-    Font_s *bigFont;
-    Font_s *smallFont;
-    Font_s *consoleFont;
-    Font_s *boldFont;
-    Font_s *textFont;
-    Font_s *extraBigFont;
-    Font_s *objectiveFont;
-    Font_s *hudBigFont;
-    Font_s *hudSmallFont;
-};
-
-struct __declspec(align(4)) sharedUiInfo_t
-{
-    CachedAssets_t assets;
-    bool preventPause;
-};
-
-struct ScreenPlacement
-{
-    float scaleVirtualToReal[2];
-    float scaleVirtualToFull[2];
-    float scaleRealToVirtual[2];
-    float realViewportPosition[2];
-    float realViewportSize[2];
-    float virtualViewableMin[2];
-    float virtualViewableMax[2];
-    float realViewableMin[2];
-    float realViewableMax[2];
-    float virtualAdjustableMin[2];
-    float virtualAdjustableMax[2];
-    float realAdjustableMin[2];
-    float realAdjustableMax[2];
-    float subScreenLeft;
-};
-
-enum XAssetType : __int32
-{
-    ASSET_TYPE_PHYSPRESET = 0x0,
-    ASSET_TYPE_PHYSCOLLMAP = 0x1,
-    ASSET_TYPE_XANIMPARTS = 0x2,
-    ASSET_TYPE_XMODEL_SURFS = 0x3,
-    ASSET_TYPE_XMODEL = 0x4,
-    ASSET_TYPE_MATERIAL = 0x5,
-    ASSET_TYPE_PIXELSHADER = 0x6,
-    ASSET_TYPE_TECHNIQUE_SET = 0x7,
-    ASSET_TYPE_IMAGE = 0x8,
-    ASSET_TYPE_SOUND = 0x9,
-    ASSET_TYPE_SOUND_CURVE = 0xA,
-    ASSET_TYPE_LOADED_SOUND = 0xB,
-    ASSET_TYPE_CLIPMAP_SP = 0xC,
-    ASSET_TYPE_CLIPMAP_MP = 0xD,
-    ASSET_TYPE_COMWORLD = 0xE,
-    ASSET_TYPE_GAMEWORLD_SP = 0xF,
-    ASSET_TYPE_GAMEWORLD_MP = 0x10,
-    ASSET_TYPE_MAP_ENTS = 0x11,
-    ASSET_TYPE_FXWORLD = 0x12,
-    ASSET_TYPE_GFXWORLD = 0x13,
-    ASSET_TYPE_LIGHT_DEF = 0x14,
-    ASSET_TYPE_UI_MAP = 0x15,
-    ASSET_TYPE_FONT = 0x16,
-    ASSET_TYPE_MENULIST = 0x17,
-    ASSET_TYPE_MENU = 0x18,
-    ASSET_TYPE_LOCALIZE_ENTRY = 0x19,
-    ASSET_TYPE_WEAPON = 0x1A,
-    ASSET_TYPE_SNDDRIVER_GLOBALS = 0x1B,
-    ASSET_TYPE_FX = 0x1C,
-    ASSET_TYPE_IMPACT_FX = 0x1D,
-    ASSET_TYPE_AITYPE = 0x1E,
-    ASSET_TYPE_MPTYPE = 0x1F,
-    ASSET_TYPE_CHARACTER = 0x20,
-    ASSET_TYPE_XMODELALIAS = 0x21,
-    ASSET_TYPE_RAWFILE = 0x22,
-    ASSET_TYPE_STRINGTABLE = 0x23,
-    ASSET_TYPE_LEADERBOARD = 0x24,
-    ASSET_TYPE_STRUCTURED_DATA_DEF = 0x25,
-    ASSET_TYPE_TRACER = 0x26,
-    ASSET_TYPE_VEHICLE = 0x27,
-    ASSET_TYPE_ADDON_MAP_ENTS = 0x28,
-    ASSET_TYPE_COUNT = 0x29,
-    ASSET_TYPE_STRING = 0x29,
-    ASSET_TYPE_ASSETLIST = 0x2A,
-};
-
-struct cplane_s;
-struct cStaticModel_s;
-struct ClipMaterial
-{
-    const char *name;
-    int surfaceFlags;
-    int contentFlags;
-};
-struct cbrushside_t;
-struct cNode_t;
-struct cLeaf_t;
-struct cLeafBrushNode_s;
-struct CollisionBorder;
-struct CollisionPartition;
-struct CollisionAabbTree;
-struct cmodel_t;
-struct cbrush_t;
-
-struct TriggerModel
-{
-    int contents;
-    unsigned __int16 hullCount;
-    unsigned __int16 firstHull;
-};
-
-struct TriggerHull
-{
-    Bounds bounds;
-    int contents;
-    unsigned __int16 slabCount;
-    unsigned __int16 firstSlab;
-};
-
-struct TriggerSlab
-{
-    float dir[3];
-    float midPoint;
-    float halfSize;
-};
-
-struct MapTriggers
-{
-    unsigned int count;
-    TriggerModel *models;
-    unsigned int hullCount;
-    TriggerHull *hulls;
-    unsigned int slabCount;
-    TriggerSlab *slabs;
-};
-
-struct __declspec(align(2)) Stage
-{
-    const char *name;
-    float origin[3];
-    unsigned __int16 triggerIndex;
-    unsigned __int8 sunPrimaryLightIndex;
-};
-
-struct __declspec(align(4)) MapEnts
-{
-    const char *name;
-    char *entityString;
-    int numEntityChars;
-    MapTriggers trigger;
-    Stage *stages;
-    unsigned __int8 stageCount;
-};
-
-struct SModelAabbNode;
-struct DynEntityDef;
-struct DynEntityPose;
-struct DynEntityClient;
-struct DynEntityColl;
-
-struct __declspec(align(64)) clipMap_t
-{
-    const char *name;
-    int isInUse;
-    int planeCount;
-    cplane_s *planes;
-    unsigned int numStaticModels;
-    cStaticModel_s *staticModelList;
-    unsigned int numMaterials;
-    ClipMaterial *materials;
-    unsigned int numBrushSides;
-    cbrushside_t *brushsides;
-    unsigned int numBrushEdges;
-    unsigned __int8 *brushEdges;
-    unsigned int numNodes;
-    cNode_t *nodes;
-    unsigned int numLeafs;
-    cLeaf_t *leafs;
-    unsigned int leafbrushNodesCount;
-    cLeafBrushNode_s *leafbrushNodes;
-    unsigned int numLeafBrushes;
-    unsigned __int16 *leafbrushes;
-    unsigned int numLeafSurfaces;
-    unsigned int *leafsurfaces;
-    unsigned int vertCount;
-    float (*verts)[3];
-    int triCount;
-    unsigned __int16 *triIndices;
-    unsigned __int8 *triEdgeIsWalkable;
-    int borderCount;
-    CollisionBorder *borders;
-    int partitionCount;
-    CollisionPartition *partitions;
-    int aabbTreeCount;
-    CollisionAabbTree *aabbTrees;
-    unsigned int numSubModels;
-    cmodel_t *cmodels;
-    unsigned __int16 numBrushes;
-    cbrush_t *brushes;
-    Bounds *brushBounds;
-    int *brushContents;
-    MapEnts *mapEnts;
-    unsigned __int16 smodelNodeCount;
-    SModelAabbNode *smodelNodes;
-    unsigned __int16 dynEntCount[2];
-    DynEntityDef *dynEntDefList[2];
-    DynEntityPose *dynEntPoseList[2];
-    DynEntityClient *dynEntClientList[2];
-    DynEntityColl *dynEntCollList[2];
-    unsigned int checksum;
-};
-
-struct pathnode_t;
-struct pathbasenode_t;
-struct pathnode_tree_t;
-struct VehicleTrackSegment;
-struct G_GlassData;
-
-struct PathData
-{
-    unsigned int nodeCount;
-    pathnode_t *nodes;
-    pathbasenode_t *basenodes;
-    unsigned int chainNodeCount;
-    unsigned __int16 *chainNodeForNode;
-    unsigned __int16 *nodeForChainNode;
-    int visBytes;
-    unsigned __int8 *pathVis;
-    int nodeTreeCount;
-    pathnode_tree_t *nodeTree;
-};
-
-struct VehicleTrack
-{
-    VehicleTrackSegment *segments;
-    unsigned int segmentCount;
-};
-
-struct GameWorldSp
-{
-    const char *name;
-    PathData path;
-    VehicleTrack vehicleTrack;
-    G_GlassData *g_glassData;
-};
-
-struct GameWorldMp
-{
-    const char *name;
-    G_GlassData *g_glassData;
-};
-
-struct RawFile
-{
-    const char *name;
-    int compressedLen;
-    int len;
-    const char *buffer;
-};
-
-struct StringTableCell
-{
-    const char *string;
-    int hash;
-};
-
-static_assert(sizeof(StringTableCell) == 8, "");
-static_assert(offsetof(StringTableCell, string) == 0x0, "");
-static_assert(offsetof(StringTableCell, hash) == 0x4, "");
-
-struct StringTable
-{
-    const char *name;
-    int columnCount;
-    int rowCount;
-    StringTableCell *values;
-};
-
-static_assert(sizeof(StringTable) == 16, "");
-static_assert(offsetof(StringTable, name) == 0x0, "");
-static_assert(offsetof(StringTable, columnCount) == 0x4, "");
-static_assert(offsetof(StringTable, rowCount) == 0x8, "");
-static_assert(offsetof(StringTable, values) == 0xC, "");
-
-union XAssetHeader
-{
-    clipMap_t *clipMap;
-    GameWorldSp *gameWorldSp;
-    GameWorldMp *gameWorldMp;
-    MapEnts *mapEnts;
-    RawFile *rawfile;
-    StringTable *stringTable;
-    void *data;
-};
-
-struct XAsset
-{
-    XAssetType type;
-    XAssetHeader header;
-};
-
-struct __declspec(align(4)) XAssetEntry
-{
-    XAsset asset;
-    unsigned __int8 zoneIndex;
-    volatile unsigned __int8 inuseMask;
-    bool printedMissingAsset;
-    unsigned __int16 nextHash;
-    unsigned __int16 nextOverride;
-};
-
-union XAssetEntryPoolEntry
-{
-    XAssetEntry entry;
-    XAssetEntryPoolEntry *next;
-};
-
-static_assert(sizeof(XAssetEntry) == 0x10, "");
-static_assert(offsetof(XAssetEntry, nextHash) == 0xC, "");
-static_assert(offsetof(XAssetEntry, nextOverride) == 0xE, "");
-
-} // namespace mp_tu6
+
+        struct internal_state;
+
+        struct Sys_File
+        {
+            void* handle;
+            int startOffset;
+        };
+
+        struct DBFile
+        {
+            Sys_File handle;
+            char name[64];
+        };
+
+        struct XBlock
+        {
+            unsigned __int8* data;
+            unsigned int size;
+        };
+
+        struct XZoneMemory
+        {
+            XBlock blocks[6];
+        };
+
+        struct XZone
+        {
+            DBFile file;
+            int flags;
+            int allocType;
+            XZoneMemory mem;
+        };
+
+        struct _OVERLAPPED
+        {
+            unsigned int Internal;
+            unsigned int InternalHigh;
+            unsigned int Offset;
+            unsigned int OffsetHigh;
+            void* hEvent;
+        };
+
+        struct z_stream_s
+        {
+            unsigned __int8* next_in;
+            unsigned int avail_in;
+            unsigned int total_in;
+            unsigned __int8* next_out;
+            unsigned int avail_out;
+            unsigned int total_out;
+            char* msg;
+            internal_state* state;
+            unsigned __int8* (__fastcall* zalloc)(unsigned __int8*, unsigned int, unsigned int);
+            void(__fastcall* zfree)(unsigned __int8*, unsigned __int8*);
+            unsigned __int8* opaque;
+            int data_type;
+        };
+
+        struct DB_LoadData
+        {
+            DBFile* file;
+            int outstandingRead;
+            unsigned __int8* fileBuffer;
+            unsigned int readSize;
+            unsigned int completedReadSize;
+            unsigned int offset;
+            unsigned __int8* start_in;
+            _OVERLAPPED overlapped;
+            unsigned int readError;
+            z_stream_s stream;
+            unsigned int lookaheadReadSize;
+            unsigned int lookaheadOffset;
+            unsigned int lookaheadClearAvailIn;
+        };
+
+        union DvarValue
+        {
+            bool enabled;
+            int integer;
+            unsigned int unsignedInt;
+            float value;
+            float vector[4];
+            const char* string;
+            unsigned __int8 color[4];
+        };
+
+        struct DvarLimits_enumeration
+        {
+            int stringCount;
+            const char** strings;
+        };
+
+        struct DvarLimits_integer
+        {
+            int min;
+            int max;
+        };
+
+        struct DvarLimits_value
+        {
+            float min;
+            float max;
+        };
+
+        struct DvarLimits_vector
+        {
+            float min;
+            float max;
+        };
+
+        union DvarLimits
+        {
+            DvarLimits_enumeration enumeration;
+            DvarLimits_integer integer;
+            DvarLimits_value value;
+            DvarLimits_vector vector;
+        };
+
+        enum DvarFlags : std::uint16_t
+        {
+            DVAR_CODINFO = 0x08, // needed to properly send to clients as a dvar
+            DVAR_FLAG_SERVERINFO = 0x10,
+        };
+
+        enum svscmd_type : __int32
+        {
+            SV_CMD_CAN_IGNORE = 0x0,
+            SV_CMD_RELIABLE = 0x1,
+        };
+
+        struct dvar_t
+        {
+            const char* name;
+            const char* description;
+            unsigned __int16 flags;
+            unsigned __int8 type;
+            bool modified;
+            DvarValue current;
+            DvarValue latched;
+            DvarValue reset;
+            DvarLimits domain;
+            dvar_t* hashNext;
+        };
+
+        enum ViewLockTypes : __int32
+        {
+            PLAYERVIEWLOCK_NONE = 0x0,
+            PLAYERVIEWLOCK_FULL = 0x1,
+            PLAYERVIEWLOCK_WEAPONJITTER = 0x2,
+            PLAYERVIEWLOCKCOUNT = 0x3,
+        };
+
+        struct SprintState
+        {
+            int sprintButtonUpRequired;
+            int sprintDelay;
+            int lastSprintStart;
+            int lastSprintEnd;
+            int sprintStartMaxLength;
+        };
+
+        struct MantleState
+        {
+            float yaw;
+            int timer;
+            int transIndex;
+            int flags;
+        };
+
+        struct PlayerActiveWeaponState
+        {
+            int weapAnim;
+            int weaponTime;
+            int weaponDelay;
+            int weaponRestrictKickTime;
+            int weaponState;
+            int weapHandFlags;
+            unsigned int weaponShotCount;
+        };
+
+        struct PlayerEquippedWeaponState
+        {
+            bool usedBefore;
+            bool dualWielding;
+            unsigned __int8 weaponModel;
+            bool needsRechamber[2];
+        };
+
+        enum OffhandClass : __int32
+        {
+            OFFHAND_CLASS_NONE = 0x0,
+            OFFHAND_CLASS_FRAG_GRENADE = 0x1,
+            OFFHAND_CLASS_SMOKE_GRENADE = 0x2,
+            OFFHAND_CLASS_FLASH_GRENADE = 0x3,
+            OFFHAND_CLASS_THROWINGKNIFE = 0x4,
+            OFFHAND_CLASS_OTHER = 0x5,
+            OFFHAND_CLASS_COUNT = 0x6,
+        };
+
+        enum PlayerHandIndex : __int32
+        {
+            WEAPON_HAND_RIGHT = 0x0,
+            WEAPON_HAND_LEFT = 0x1,
+            NUM_WEAPON_HANDS = 0x2,
+            WEAPON_HAND_DEFAULT = 0x0,
+        };
+
+        enum team_t : __int32
+        {
+            TEAM_FREE = 0x0,
+            TEAM_AXIS = 0x1,
+            TEAM_ALLIES = 0x2,
+            TEAM_SPECTATOR = 0x3,
+            TEAM_NUM_TEAMS = 0x4,
+        };
+
+        struct GlobalAmmo
+        {
+            int ammoType;
+            int ammoCount;
+        };
+
+        struct ClipAmmo
+        {
+            int clipIndex;
+            int ammoCount[2];
+        };
+
+        struct PlayerWeaponCommonState
+        {
+            int offHandIndex;
+            OffhandClass offhandPrimary;
+            OffhandClass offhandSecondary;
+            unsigned int weapon;
+            unsigned int primaryWeaponForAltMode;
+            int weapFlags;
+            float fWeaponPosFrac;
+            float aimSpreadScale;
+            int adsDelayTime;
+            int spreadOverride;
+            int spreadOverrideState;
+            PlayerHandIndex lastWeaponHand;
+            GlobalAmmo ammoNotInClip[15];
+            ClipAmmo ammoInClip[15];
+            int weapLockFlags;
+            int weapLockedEntnum;
+            float weapLockedPos[3];
+            int weaponIdleTime;
+        };
+        static_assert(offsetof(PlayerWeaponCommonState, fWeaponPosFrac) == 0x18, "");
+
+        enum ActionSlotType : __int32
+        {
+            ACTIONSLOTTYPE_DONOTHING = 0x0,
+            ACTIONSLOTTYPE_SPECIFYWEAPON = 0x1,
+            ACTIONSLOTTYPE_ALTWEAPONTOGGLE = 0x2,
+            ACTIONSLOTTYPE_NIGHTVISION = 0x3,
+            ACTIONSLOTTYPECOUNT = 0x4,
+        };
+
+        struct ActionSlotParam_SpecifyWeapon
+        {
+            unsigned int index;
+        };
+
+        struct ActionSlotParam
+        {
+            ActionSlotParam_SpecifyWeapon specifyWeapon;
+        };
+
+        enum objectiveState_t : __int32
+        {
+            OBJST_EMPTY = 0x0,
+            OBJST_ACTIVE = 0x1,
+            OBJST_INVISIBLE = 0x2,
+            OBJST_DONE = 0x3,
+            OBJST_CURRENT = 0x4,
+            OBJST_FAILED = 0x5,
+            OBJST_NUMSTATES = 0x6,
+        };
+
+        struct objective_t
+        {
+            objectiveState_t state;
+            float origin[3];
+            int entNum;
+            int teamNum;
+            int icon;
+        };
+
+        enum he_type_t : __int32
+        {
+            HE_TYPE_FREE = 0x0,
+            HE_TYPE_TEXT = 0x1,
+            HE_TYPE_VALUE = 0x2,
+            HE_TYPE_PLAYERNAME = 0x3,
+            HE_TYPE_MAPNAME = 0x4,
+            HE_TYPE_GAMETYPE = 0x5,
+            HE_TYPE_MATERIAL = 0x6,
+            HE_TYPE_TIMER_DOWN = 0x7,
+            HE_TYPE_TIMER_UP = 0x8,
+            HE_TYPE_TENTHS_TIMER_DOWN = 0x9,
+            HE_TYPE_TENTHS_TIMER_UP = 0xA,
+            HE_TYPE_CLOCK_DOWN = 0xB,
+            HE_TYPE_CLOCK_UP = 0xC,
+            HE_TYPE_WAYPOINT = 0xD,
+            HE_TYPE_COUNT = 0xE,
+        };
+
+        struct $0D0CB43DF22755AD856C77DD3F304010
+        {
+            unsigned __int8 r;
+            unsigned __int8 g;
+            unsigned __int8 b;
+            unsigned __int8 a;
+        };
+
+        union hudelem_color_t
+        {
+            $0D0CB43DF22755AD856C77DD3F304010 __s0;
+            int rgba;
+        };
+
+        struct hudelem_s
+        {
+            he_type_t type;
+            float x;
+            float y;
+            float z;
+            int targetEntNum;
+            float fontScale;
+            float fromFontScale;
+            int fontScaleStartTime;
+            int fontScaleTime;
+            int font;
+            int alignOrg;
+            int alignScreen;
+            hudelem_color_t color;
+            hudelem_color_t fromColor;
+            int fadeStartTime;
+            int fadeTime;
+            int label;
+            int width;
+            int height;
+            int materialIndex;
+            int fromWidth;
+            int fromHeight;
+            int scaleStartTime;
+            int scaleTime;
+            float fromX;
+            float fromY;
+            int fromAlignOrg;
+            int fromAlignScreen;
+            int moveStartTime;
+            int moveTime;
+            int time;
+            int duration;
+            float value;
+            int text;
+            float sort;
+            hudelem_color_t glowColor;
+            int fxBirthTime;
+            int fxLetterTime;
+            int fxDecayStartTime;
+            int fxDecayDuration;
+            int soundID;
+            int flags;
+        };
+
+        struct playerState_s_hud
+        {
+            hudelem_s current[31];
+            hudelem_s archival[31];
+        };
+
+        struct __declspec(align(128)) playerState_s
+        {
+            int commandTime;
+            int pm_type;
+            int pm_time;
+            int pm_flags;
+            int otherFlags;
+            int linkFlags;
+            int bobCycle;
+            float origin[3];
+            float velocity[3];
+            int grenadeTimeLeft;
+            int throwbackGrenadeOwner;
+            int throwbackGrenadeTimeLeft;
+            unsigned int throwbackWeaponIndex;
+            int remoteEyesEnt;
+            int remoteEyesTagname;
+            int remoteControlEnt;
+            int foliageSoundTime;
+            int gravity;
+            float leanf;
+            int speed;
+            float delta_angles[3];
+            int groundEntityNum;
+            float vLadderVec[3];
+            int jumpTime;
+            float jumpOriginZ;
+            int legsTimer;
+            int legsAnim;
+            int torsoTimer;
+            int torsoAnim;
+            int legsAnimDuration;
+            int torsoAnimDuration;
+            int damageTimer;
+            int damageDuration;
+            int flinchYawAnim;
+            int corpseIndex;
+            int movementDir;
+            int eFlags;
+            int eventSequence;
+            int events[4];
+            unsigned int eventParms[4];
+            int oldEventSequence;
+            int unpredictableEventSequence;
+            int unpredictableEventSequenceOld;
+            int unpredictableEvents[4];
+            unsigned int unpredictableEventParms[4];
+            int clientNum;
+            int viewmodelIndex;
+            float viewangles[3];
+            int viewHeightTarget;
+            float viewHeightCurrent;
+            int viewHeightLerpTime;
+            int viewHeightLerpTarget;
+            int viewHeightLerpDown;
+            float viewAngleClampBase[2];
+            float viewAngleClampRange[2];
+            int damageEvent;
+            int damageYaw;
+            int damagePitch;
+            int damageCount;
+            int damageFlags;
+            int stats[4];
+            float proneDirection;
+            float proneDirectionPitch;
+            float proneTorsoPitch;
+            ViewLockTypes viewlocked;
+            int viewlocked_entNum;
+            float linkAngles[3];
+            float linkWeaponAngles[3];
+            int linkWeaponEnt;
+            int loopSound;
+            int cursorHint;
+            int cursorHintString;
+            int cursorHintEntIndex;
+            int cursorHintDualWield;
+            int iCompassPlayerInfo;
+            int radarEnabled;
+            int radarBlocked;
+            int radarMode;
+            int locationSelectionInfo;
+            SprintState sprintState;
+            float holdBreathScale;
+            int holdBreathTimer;
+            float moveSpeedScaleMultiplier;
+            MantleState mantleState;
+            PlayerActiveWeaponState weapState[2];
+            unsigned int weaponsEquipped[15];
+            PlayerEquippedWeaponState weapEquippedData[15];
+            PlayerWeaponCommonState weapCommon;
+            float meleeChargeYaw;
+            int meleeChargeDist;
+            int meleeChargeTime;
+            unsigned int perks[2];
+            unsigned int perkSlots[8];
+            ActionSlotType actionSlotType[4];
+            ActionSlotParam actionSlotParam[4];
+            int weaponHudIconOverrides[6];
+            int animScriptedType;
+            int shellshockIndex;
+            int shellshockTime;
+            int shellshockDuration;
+            float dofNearStart;
+            float dofNearEnd;
+            float dofFarStart;
+            float dofFarEnd;
+            float dofNearBlur;
+            float dofFarBlur;
+            float dofViewmodelStart;
+            float dofViewmodelEnd;
+            objective_t objective[32];
+            int deltaTime;
+            int killCamEntity;
+            int killCamLookAtEntity;
+            int killCamClientNum;
+            playerState_s_hud hud;
+            unsigned int partBits[5];
+            int recoilScale;
+            int diveDirection;
+            int stunTime;
+        };
+
+        static_assert(sizeof(playerState_s) == 12672, "");
+        static_assert(offsetof(playerState_s, velocity) == 40, "");
+        static_assert(offsetof(playerState_s, delta_angles) == 96, "");
+
+        struct gclient_s;
+        struct Turret;
+        struct Vehicle;
+        struct tagInfo_s;
+
+        enum trType_t : __int32
+        {
+            TR_STATIONARY = 0x0,
+            TR_INTERPOLATE = 0x1,
+            TR_LINEAR = 0x2,
+            TR_LINEAR_STOP = 0x3,
+            TR_SINE = 0x4,
+            TR_GRAVITY = 0x5,
+            TR_LOW_GRAVITY = 0x6,
+            TR_ACCELERATE = 0x7,
+            TR_DECELERATE = 0x8,
+            TR_PHYSICS = 0x9,
+            TR_FIRST_RAGDOLL = 0xA,
+            TR_RAGDOLL = 0xA,
+            TR_RAGDOLL_GRAVITY = 0xB,
+            TR_RAGDOLL_INTERPOLATE = 0xC,
+            TR_LAST_RAGDOLL = 0xC,
+            NUM_TRTYPES = 0xD,
+        };
+
+        struct trajectory_t
+        {
+            trType_t trType;
+            int trTime;
+            int trDuration;
+            float trBase[3];
+            float trDelta[3];
+        };
+
+        struct LerpEntityStateTurret
+        {
+            float gunAngles[3];
+            int lastBarrelRotChangeTime;
+            int lastBarrelRotChangeRate;
+            int lastHeatChangeLevel;
+            int lastHeatChangeTime;
+            bool isBarrelRotating;
+            bool isOverheat;
+            bool isHeatingUp;
+            bool isBeingCarried;
+        };
+
+        struct LerpEntityStateLoopFx
+        {
+            float cullDist;
+            int period;
+        };
+
+        struct LerpEntityStatePrimaryLight
+        {
+            unsigned __int8 colorAndExp[4];
+            float intensity;
+            float radius;
+            float cosHalfFovOuter;
+            float cosHalfFovInner;
+        };
+
+        struct LerpEntityStatePlayer
+        {
+            float leanf;
+            int movementDir;
+            float torsoPitch;
+            float waistPitch;
+            unsigned int offhandWeapon;
+            int lastSpawnTime;
+        };
+
+        struct LerpEntityStateVehicle
+        {
+            unsigned int indices;
+            unsigned int flags;
+            float bodyPitch;
+            float bodyRoll;
+            float steerYaw;
+            float gunPitch;
+            float gunYaw;
+            int playerIndex;
+            int pad;
+        };
+
+        struct LerpEntityStatePlane
+        {
+            int ownerNum;
+            int enemyIcon;
+            int friendIcon;
+        };
+
+        enum MissileFlightMode : __int32
+        {
+            MISSILEFLIGHTMODE_TOP = 0x0,
+            MISSILEFLIGHTMODE_DIRECT = 0x1,
+            MISSILEFLIGHTMODE_COUNT = 0x2,
+        };
+
+        struct LerpEntityStateMissile
+        {
+            int launchTime;
+            MissileFlightMode flightMode;
+        };
+
+        struct LerpEntityStateSoundBlend
+        {
+            float lerp;
+        };
+
+        struct LerpEntityStateBulletHit
+        {
+            float start[3];
+        };
+
+        struct LerpEntityStateEarthquake
+        {
+            float scale;
+            float radius;
+            int duration;
+        };
+
+        struct LerpEntityStateCustomExplode
+        {
+            int startTime;
+        };
+
+        struct LerpEntityStateExplosion
+        {
+            float innerRadius;
+            float outerRadius;
+            float magnitude;
+        };
+
+        struct LerpEntityStateExplosionJolt
+        {
+            float innerRadius;
+            float outerRadius;
+            float impulse[3];
+        };
+
+        struct LerpEntityStatePhysicsJitter
+        {
+            float innerRadius;
+            float outerRadius;
+            float minDisplacement;
+            float maxDisplacement;
+        };
+
+        struct LerpEntityStateRadiusDamage
+        {
+            float range;
+            int damageMin;
+            int damageMax;
+        };
+
+        struct LerpEntityStateScriptMover
+        {
+            int entToTakeMarksFrom;
+            int xModelIndex;
+            int animIndex;
+            int animTime;
+        };
+
+        struct LerpEntityStateAnonymous
+        {
+            int data[9];
+        };
+
+        union LerpEntityStateTypeUnion
+        {
+            LerpEntityStateTurret turret;
+            LerpEntityStateLoopFx loopFx;
+            LerpEntityStatePrimaryLight primaryLight;
+            LerpEntityStatePlayer player;
+            LerpEntityStateVehicle vehicle;
+            LerpEntityStatePlane plane;
+            LerpEntityStateMissile missile;
+            LerpEntityStateSoundBlend soundBlend;
+            LerpEntityStateBulletHit bulletHit;
+            LerpEntityStateEarthquake earthquake;
+            LerpEntityStateCustomExplode customExplode;
+            LerpEntityStateExplosion explosion;
+            LerpEntityStateExplosionJolt explosionJolt;
+            LerpEntityStatePhysicsJitter physicsJitter;
+            LerpEntityStateRadiusDamage radiusDamage;
+            LerpEntityStateScriptMover scriptMover;
+            LerpEntityStateAnonymous anonymous;
+        };
+
+        struct LerpEntityState
+        {
+            int eFlags;
+            trajectory_t pos;
+            trajectory_t apos;
+            LerpEntityStateTypeUnion u;
+        };
+
+        union entityState_s_index
+        {
+            int brushModel;
+            int triggerModel;
+            int item;
+            int xmodel;
+            int primaryLight;
+        };
+
+        struct entityState_s_wes
+        {
+            unsigned __int16 weapon;
+            unsigned __int16 primaryWeapon;
+        };
+
+        union entityState_s_un1
+        {
+            int eventParm2;
+            int hintString;
+            int fxId;
+            int helicopterStage;
+        };
+
+        union entityState_s_un2
+        {
+            int hintType;
+            int vehicleXModel;
+            int actorFlags;
+            unsigned __int8 weaponModel;
+        };
+
+        struct clientLinkInfo_t
+        {
+            unsigned __int8 flags;
+            unsigned __int8 tagName;
+            __int16 parentId;
+        };
+
+        struct entityState_s
+        {
+            int number;
+            int eType;
+            LerpEntityState lerp;
+            int time2;
+            int otherEntityNum;
+            int attackerEntityNum;
+            int groundEntityNum;
+            int loopSound;
+            int surfType;
+            entityState_s_index index;
+            int clientNum;
+            int iHeadIcon;
+            int iHeadIconTeam;
+            int solid;
+            unsigned int eventParm;
+            int eventSequence;
+            int events[4];
+            unsigned int eventParms[4];
+            entityState_s_wes wes;
+            int legsAnim;
+            int torsoAnim;
+            entityState_s_un1 un1;
+            entityState_s_un2 un2;
+            clientLinkInfo_t clientLinkInfo;
+            unsigned int partBits[5];
+            int clientMask[1];
+            unsigned int pad[1];
+        };
+
+        struct EntHandle
+        {
+            unsigned __int16 number;
+            unsigned __int16 infoIndex;
+        };
+
+        struct Bounds
+        {
+            float midPoint[3];
+            float halfSize[3];
+        };
+
+        struct entityShared_t
+        {
+            unsigned __int8 isLinked;
+            unsigned __int8 modelType;
+            unsigned __int8 svFlags;
+            unsigned __int8 isInUse;
+            Bounds box;
+            int contents;
+            Bounds absBox;
+            float currentOrigin[3];
+            float currentAngles[3];
+            EntHandle ownerNum;
+            int eventTime;
+        };
+
+        struct __declspec(align(4)) item_ent_t
+        {
+            int ammoCount;
+            int clipAmmoCount[2];
+            int index;
+            bool dualWieldItem;
+        };
+
+        struct spawner_ent_t
+        {
+            int team;
+            int timestamp;
+            int index;
+        };
+
+        struct __declspec(align(4)) trigger_ent_t
+        {
+            int threshold;
+            int accumulate;
+            int timestamp;
+            int singleUserEntIndex;
+            bool requireLookAt;
+        };
+
+        struct mover_positions_t
+        {
+            float decelTime;
+            float speed;
+            float midTime;
+            float pos1[3];
+            float pos2[3];
+            float pos3[3];
+        };
+
+        struct mover_slidedata_t
+        {
+            Bounds bounds;
+            float velocity[3];
+        };
+
+        struct mover_ent_t
+        {
+            union
+            {
+                mover_positions_t pos;
+                mover_slidedata_t slide;
+            } ___u0;
+            mover_positions_t angle;
+        };
+
+        struct corpse_ent_t
+        {
+            int deathAnimStartTime;
+        };
+
+        struct missile_fields_grenade
+        {
+            float wobbleCycle;
+            float curve;
+        };
+
+        enum MissileStage : __int32
+        {
+            MISSILESTAGE_SOFTLAUNCH = 0x0,
+            MISSILESTAGE_ASCENT = 0x1,
+            MISSILESTAGE_DESCENT = 0x2,
+        };
+
+        struct missile_fields_nonGrenade
+        {
+            float curvature[3];
+            float targetEntOffset[3];
+            float targetPos[3];
+            float launchOrigin[3];
+            MissileStage stage;
+        };
+
+        struct missile_ent_t
+        {
+            float time;
+            int timeOfBirth;
+            float travelDist;
+            float surfaceNormal[3];
+            team_t team;
+            int flags;
+            int antilagTimeOffset;
+            union
+            {
+                missile_fields_grenade grenade;
+                missile_fields_nonGrenade nonGrenade;
+            } ___u7;
+        };
+
+        struct blend_ent_t
+        {
+            float pos[3];
+            float vel[3];
+            float viewQuat[4];
+            bool changed;
+            float accelTime;
+            float decelTime;
+            float startTime;
+            float totalTime;
+        };
+
+        enum entityFlag_t : uint32_t
+        {
+            FL_GODMODE = 0x1,
+            FL_DEMI_GODMODE = 0x2,
+            FL_NOTARGET = 0x4,
+            FL_NO_KNOCKBACK = 0x8,
+            FL_NO_RADIUS_DAMAGE = 0x10,
+            FL_SUPPORTS_LINKTO = 0x1000,
+            FL_NO_AUTO_ANIM_UPDATE = 0x2000,
+            FL_GRENADE_TOUCH_DAMAGE = 0x4000,
+            FL_STABLE_MISSILES = 0x20000,
+            FL_REPEAT_ANIM_UPDATE = 0x40000,
+            FL_VEHICLE_TARGET = 0x80000,
+            FL_GROUND_ENT = 0x100000,
+            FL_CURSOR_HINT = 0x200000,
+            FL_MISSILE_ATTRACTOR = 0x800000,
+            FL_WEAPON_BEING_GRABBED = 0x1000000,
+            FL_DELETE = 0x2000000,
+            FL_BOUNCE = 0x4000000,
+            FL_MOVER_SLIDE = 0x8000000,
+        };
+
+        enum clientFlag_t : uint32_t
+        {
+            CF_NOCLIP = 1u << 0,
+            CF_UFO = 1u << 1,
+            CF_FROZEN = 1u << 2,
+            CF_DISABLE_USABILITY = 1u << 3,
+            CF_NO_KNOCKBACK = 1u << 4,
+        };
+
+        struct gentity_s
+        {
+            entityState_s s;
+            entityShared_t r;
+            gclient_s* client;
+            Turret* turret;
+            Vehicle* vehicle;
+            int physObjId;
+            unsigned __int16 model;
+            unsigned __int8 physicsObject;
+            unsigned __int8 takedamage;
+            unsigned __int8 active;
+            unsigned __int8 handler;
+            unsigned __int8 team;
+            bool freeAfterEvent;
+            __int16 padding_short;
+            unsigned __int16 classname;
+            unsigned __int16 script_classname;
+            unsigned __int16 script_linkName;
+            unsigned __int16 target;
+            unsigned __int16 targetname;
+            unsigned int attachIgnoreCollision;
+            int spawnflags;
+            int flags;
+            int eventTime;
+            int clipmask;
+            int processedFrame;
+            EntHandle parent;
+            int nextthink;
+            int health;
+            int maxHealth;
+            int damage;
+            int count;
+            union
+            {
+                item_ent_t item[2];
+                spawner_ent_t spawner;
+                trigger_ent_t trigger;
+                mover_ent_t mover;
+                corpse_ent_t corpse;
+                missile_ent_t missile;
+                blend_ent_t blend;
+            } ___u31;
+            EntHandle missileTargetEnt;
+            EntHandle remoteControlledOwner;
+            tagInfo_s* tagInfo;
+            gentity_s* tagChildren;
+            unsigned __int16 attachModelNames[19];
+            unsigned __int16 attachTagNames[19];
+            int useCount;
+            gentity_s* nextFree;
+            int birthTime;
+            int padding[3];
+        };
+        static_assert(sizeof(gentity_s) == 640, "");
+        static_assert(offsetof(gentity_s, client) == 344, "");
+        static_assert(offsetof(gentity_s, flags) == 0x184, "");
+
+        struct sentient_s;
+        struct actor_s;
+
+        struct level_locals_t
+        {
+            gclient_s* clients;
+            gentity_s* gentities;
+            int num_entities;
+            gentity_s* firstFreeEnt;
+            gentity_s* lastFreeEnt;
+            sentient_s* sentients;
+            actor_s* actors;
+            Vehicle* vehicles;
+            Turret* turrets;
+            int initializing;
+            int clientIsSpawning;
+            char pad_2C[0x3A4 - 0x2C];
+            int maxclients;
+        };
+        static_assert(offsetof(level_locals_t, clients) == 0x0, "");
+        static_assert(offsetof(level_locals_t, gentities) == 0x4, "");
+        static_assert(offsetof(level_locals_t, num_entities) == 0x8, "");
+        static_assert(offsetof(level_locals_t, maxclients) == 0x3A4, "");
+
+        enum weapInventoryType_t
+        {
+            WEAPINVENTORY_PRIMARY = 0x0,
+            WEAPINVENTORY_OFFHAND = 0x1,
+            WEAPINVENTORY_ITEM = 0x2,
+            WEAPINVENTORY_ALTMODE = 0x3,
+            WEAPINVENTORY_EXCLUSIVE = 0x4,
+            WEAPINVENTORY_SCAVENGER = 0x5,
+            WEAPINVENTORYCOUNT = 0x6,
+        };
+
+        struct WeaponDef
+        {
+            char pad[0x38];
+            weapInventoryType_t inventoryType;
+        };
+        static_assert(offsetof(WeaponDef, inventoryType) == 0x38, "");
+
+        struct WeaponCompleteDef
+        {
+            const char* szInternalName;
+            WeaponDef* weapDef;
+            char pad[0x38];
+            int altWeaponIndex;
+        };
+        static_assert(offsetof(WeaponCompleteDef, weapDef) == 0x4, "");
+        static_assert(offsetof(WeaponCompleteDef, altWeaponIndex) == 0x40, "");
+
+        struct weaponParms
+        {
+            float forward[3];
+            float right[3];
+            float up[3];
+            float muzzleTrace[3];
+            float gunForward[3];
+            unsigned int weaponIndex;
+            const struct WeaponDef* weapDef;
+            const struct WeaponCompleteDef* weapCompleteDef;
+        };
+        static_assert(sizeof(weaponParms) == 0x48, "");
+
+        struct weaponState_t;
+        struct viewState_t;
+
+        struct scr_entref_t
+        {
+            unsigned __int16 entnum;
+            unsigned __int16 classnum;
+        };
+
+        enum ClassNum : __int32
+        {
+            CLASS_NUM_ENTITY = 0x0,
+            CLASS_NUM_HUDELEM = 0x1,
+            CLASS_NUM_PATHNODE = 0x2,
+            CLASS_NUM_VEHICLENODE = 0x3,
+            CLASS_NUM_VEHTRACK_SEGMENT = 0x4,
+            CLASS_NUM_FXENTITY = 0x5,
+            CLASS_NUM_COUNT = 0x6,
+        };
+
+        struct cmd_function_s
+        {
+            cmd_function_s* next;
+            const char* name;
+            const char* autoCompleteDir;
+            const char* autoCompleteExt;
+            void (*function)();
+        };
+
+        enum usercmdButtonBits
+        {
+            CMD_BUTTON_ATTACK = 1 << 0,
+            CMD_BUTTON_SPRINT = 1 << 1,
+            CMD_BUTTON_MELEE = 1 << 2,
+            CMD_BUTTON_ACTIVATE = 1 << 3,
+            CMD_BUTTON_RELOAD = 1 << 4,
+            CMD_BUTTON_USE_RELOAD = 1 << 5,
+            CMD_BUTTON_LEAN_LEFT = 1 << 6,
+            CMD_BUTTON_LEAN_RIGHT = 1 << 7,
+            CMD_BUTTON_PRONE = 1 << 8,
+            CMD_BUTTON_CROUCH = 1 << 9,
+            CMD_BUTTON_UP = 1 << 10,
+            CMD_BUTTON_ADS = 1 << 11,
+            CMD_BUTTON_DOWN = 1 << 12,
+            CMD_BUTTON_BREATH = 1 << 13,
+            CMD_BUTTON_FRAG = 1 << 14,
+            CMD_BUTTON_OFFHAND_SECONDARY = 1 << 15,
+            CMD_BUTTON_THROW = 1 << 19,
+            CMD_BUTTON_REMOTE = 1 << 20,
+        };
+        static_assert(sizeof(usercmdButtonBits) == 4, "");
+
+        struct __declspec(align(4)) usercmd_s
+        {
+            int serverTime;
+            int buttons;
+            int angles[3];
+            unsigned __int16 weapon;
+            unsigned __int16 primaryWeaponForAltMode;
+            unsigned __int16 offHandIndex;
+            char forwardmove;
+            char rightmove;
+            float meleeChargeYaw;
+            unsigned __int8 meleeChargeDist;
+            char selectedLoc[2];
+            unsigned __int8 selectedLocAngle;
+            char remoteControlAngles[2];
+        };
+        static_assert(sizeof(usercmd_s) == 0x28, "");
+        static_assert(offsetof(usercmd_s, serverTime) == 0x0, "");
+        static_assert(offsetof(usercmd_s, buttons) == 0x4, "");
+        static_assert(offsetof(usercmd_s, angles) == 0x8, "");
+        static_assert(offsetof(usercmd_s, weapon) == 0x14, "");
+        static_assert(offsetof(usercmd_s, primaryWeaponForAltMode) == 0x16, "");
+        static_assert(offsetof(usercmd_s, offHandIndex) == 0x18, "");
+        static_assert(offsetof(usercmd_s, forwardmove) == 0x1A, "");
+        static_assert(offsetof(usercmd_s, rightmove) == 0x1B, "");
+        static_assert(offsetof(usercmd_s, meleeChargeYaw) == 0x1C, "");
+        static_assert(offsetof(usercmd_s, meleeChargeDist) == 0x20, "");
+        static_assert(offsetof(usercmd_s, remoteControlAngles) == 0x24, "");
+
+        enum netadrtype_t : __int32
+        {
+            NA_BOT = 0x0,
+        };
+
+        struct netadr_t
+        {
+            netadrtype_t type;
+        };
+        static_assert(offsetof(netadr_t, type) == 0x0, "");
+
+        struct netchan_t
+        {
+            char pad_0[0x4];
+            int outgoingSequence;
+            char pad_8[0xC];
+            netadr_t remoteAddress;
+        };
+        static_assert(offsetof(netchan_t, outgoingSequence) == 0x4, "");
+        static_assert(offsetof(netchan_t, remoteAddress) == 0x14, "");
+
+        struct clientHeader_t
+        {
+            int state;
+            char pad_4[0x4];
+            int deltaMessage;
+            char pad_C[0x8];
+            netchan_t netchan;
+        };
+        static_assert(offsetof(clientHeader_t, state) == 0x0, "");
+        static_assert(offsetof(clientHeader_t, deltaMessage) == 0x8, "");
+        static_assert(offsetof(clientHeader_t, netchan) == 0x14, "");
+        static_assert(offsetof(clientHeader_t, netchan) + offsetof(netchan_t, outgoingSequence) == 0x18, "");
+        static_assert(offsetof(clientHeader_t, netchan) + offsetof(netchan_t, remoteAddress) + offsetof(netadr_t, type) == 0x28,
+            "");
+
+        struct client_t
+        {
+            clientHeader_t header;
+            const char* dropReason;
+            char pad_30[0x650 - 0x30];
+            char userinfo[1024];
+            char pad_A50[0x21294 - 0xA50];
+            gentity_s* gentity;
+            char name[32];
+            char clanAbbrev[5];
+            char pad_212BD[0x212D4 - 0x212BD];
+            int ping;
+            char pad_212D8[0x97F80 - 0x212D8];
+        };
+        static_assert(sizeof(client_t) == 0x97F80, "");
+        static_assert(offsetof(client_t, header) == 0x0, "");
+        static_assert(offsetof(client_t, header) + offsetof(clientHeader_t, deltaMessage) == 0x8, "");
+        static_assert(offsetof(client_t, dropReason) == 0x2C, "");
+        static_assert(offsetof(client_t, userinfo) == 0x650, "");
+        static_assert(offsetof(client_t, gentity) == 0x21294, "");
+        static_assert(offsetof(client_t, name) == 0x21298, "");
+        static_assert(offsetof(client_t, clanAbbrev) == 0x212B8, "");
+        static_assert(offsetof(client_t, ping) == 0x212D4, "");
+
+        struct serverStaticHeader_t
+        {
+            int time;
+            int timeResidual;
+            int clientCount;
+            client_t* clients;
+        };
+        static_assert(offsetof(serverStaticHeader_t, time) == 0x0, "");
+        static_assert(offsetof(serverStaticHeader_t, clientCount) == 0x8, "");
+        static_assert(offsetof(serverStaticHeader_t, clients) == 0xC, "");
+
+        struct __declspec(align(128)) clSnapshot_t
+        {
+            playerState_s ps;
+            int valid;
+            int snapFlags;
+            int serverTime;
+            int messageNum;
+            int deltaNum;
+            int ping;
+            int cmdNum;
+            int numEntities;
+            int numClients;
+            int parseEntitiesIndex;
+            int parseClientsIndex;
+            int serverCommandNum;
+        };
+
+        enum StanceState : __int32
+        {
+            CL_STANCE_STAND = 0x0,
+            CL_STANCE_CROUCH = 0x1,
+            CL_STANCE_PRONE = 0x2,
+        };
+
+        struct ClientArchiveData
+        {
+            int serverTime;
+            float origin[3];
+            float velocity[3];
+            int bobCycle;
+            int movementDir;
+        };
+
+        struct outPacket_t
+        {
+            int p_cmdNumber;
+            int p_serverTime;
+            int p_realtime;
+        };
+
+        struct clientState_s
+        {
+            int clientIndex;
+            team_t team;
+            int modelindex;
+            int dualWielding;
+            int riotShieldNext;
+            int attachModelIndex[6];
+            int attachTagIndex[6];
+            char name[32];
+            float maxSprintTimeMultiplier;
+            int rank;
+            int prestige;
+            unsigned int perks[2];
+            int diveState;
+            int voiceConnectivityBits;
+            char clanAbbrev[8];
+            unsigned int playerCardIcon;
+            unsigned int playerCardTitle;
+            unsigned int playerCardNameplate;
+        };
+
+        enum sessionState_t : __int32
+        {
+            SESS_STATE_PLAYING = 0x0,
+            SESS_STATE_DEAD = 0x1,
+            SESS_STATE_SPECTATOR = 0x2,
+            SESS_STATE_INTERMISSION = 0x3,
+        };
+
+        enum clientConnected_t : __int32
+        {
+            CON_DISCONNECTED = 0x0,
+            CON_CONNECTING = 0x1,
+            CON_CONNECTED = 0x2,
+        };
+
+        struct playerTeamState_t
+        {
+            int location;
+        };
+
+        struct clientSession_t
+        {
+            sessionState_t sessionState;
+            int forceSpectatorClient;
+            int killCamEntity;
+            int killCamLookAtEntity;
+            int status_icon;
+            int archiveTime;
+            int score;
+            int deaths;
+            int kills;
+            int assists;
+            unsigned __int16 scriptPersId;
+            clientConnected_t connected;
+            usercmd_s cmd;
+            usercmd_s oldcmd;
+            int localClient;
+            int predictItemPickup;
+            char newnetname[32];
+            int maxHealth;
+            int enterTime;
+            playerTeamState_t teamState;
+            int voteCount;
+            int teamVoteCount;
+            float moveSpeedScaleMultiplier;
+            int viewmodelIndex;
+            int noSpectate;
+            int teamInfo;
+            clientState_s cs;
+            int psOffsetTime;
+            int hasRadar;
+            int isRadarBlocked;
+            int radarMode;
+            int weaponHudIconOverrides[6];
+            unsigned int unusableEntFlags[64];
+            float spectateDefaultPos[3];
+            float spectateDefaultAngles[3];
+        };
+        static_assert(sizeof(clientSession_t) == 0x2A0, "");
+        static_assert(offsetof(clientSession_t, connected) == 0x2C, "");
+        static_assert(offsetof(clientSession_t, cmd) == 0x30, "");
+        static_assert(offsetof(clientSession_t, cs) == 0xCC, "");
+
+        struct viewClamp
+        {
+            float start[2];
+            float current[2];
+            float goal[2];
+        };
+
+        struct viewClampState
+        {
+            viewClamp min;
+            viewClamp max;
+            float accelTime;
+            float decelTime;
+            float totalTime;
+            float startTime;
+        };
+
+        enum hintType_t : __int32
+        {
+            HINT_NONE = 0x0,
+            HINT_NOICON = 0x1,
+            HINT_ACTIVATE = 0x2,
+            HINT_HEALTH = 0x3,
+            HINT_FRIENDLY = 0x4,
+            FIRST_WEAPON_HINT = 0x5,
+            LAST_WEAPON_HINT = 0x4B4,
+            HINT_NUM_HINTS = 0x4B5,
+        };
+
+        struct gclient_s
+        {
+            playerState_s ps;
+            clientSession_t sess;
+            int flags;
+            int spectatorClient;
+            int lastCmdTime;
+            int mpviewer;
+            int buttons;
+            int oldbuttons;
+            int latched_buttons;
+            int buttonsSinceLastFrame;
+            float oldOrigin[3];
+            float fGunPitch;
+            float fGunYaw;
+            int damage_blood;
+            int damage_stun;
+            float damage_from[3];
+            int damage_fromWorld;
+            int accurateCount;
+            int accuracy_shots;
+            int accuracy_hits;
+            int inactivityTime;
+            int inactivityWarning;
+            int lastVoiceTime;
+            int switchTeamTime;
+            float currentAimSpreadScale;
+            float prevLinkedInvQuat[4];
+            bool prevLinkAnglesSet;
+            bool link_rotationMovesEyePos;
+            bool link_doCollision;
+            bool link_useTagAnglesForViewAngles;
+            float linkAnglesFrac;
+            viewClampState link_viewClamp;
+            gentity_s* persistantPowerup;
+            int portalID;
+            int dropWeaponTime;
+            int sniperRifleFiredTime;
+            float sniperRifleMuzzleYaw;
+            int PCSpecialPickedUpCount;
+            EntHandle useHoldEntity;
+            int useHoldTime;
+            int useButtonDone;
+            int iLastCompassPlayerInfoEnt;
+            int compassPingTime;
+            int damageTime;
+            float v_dmg_roll;
+            float v_dmg_pitch;
+            float baseAngles[3];
+            float baseOrigin[3];
+            float swayViewAngles[3];
+            float swayOffset[3];
+            float swayAngles[3];
+            float recoilAngles[3];
+            float recoilSpeed[3];
+            float fLastIdleFactor;
+            int weapIdleTime;
+            int lastServerTime;
+            unsigned int lastWeapon;
+            bool previouslyFiring;
+            bool previouslyFiringLeftHand;
+            bool previouslyUsingNightVision;
+            bool previouslySprinting;
+            int visionDuration[5];
+            char visionName[5][64];
+            int lastStand;
+            int lastStandTime;
+            int hudElemLastAssignedSoundID;
+            float lockedTargetOffset[3];
+            int attachShieldTagName;
+            hintType_t hintForcedType;
+            int hintForcedString;
+            int padding;
+        };
+        static_assert(sizeof(gclient_s) == 0x3700, "");
+        static_assert(offsetof(gclient_s, ps) == 0x0, "");
+        static_assert(offsetof(gclient_s, sess) == 0x3180, "");
+        static_assert(offsetof(gclient_s, flags) == 0x3420, "");
+        static_assert(offsetof(gclient_s, buttons) == 0x3430, "");
+        static_assert(offsetof(gclient_s, attachShieldTagName) == 0x36F0, "");
+        static_assert(offsetof(gclient_s, hintForcedType) == 0x36F4, "");
+        static_assert(offsetof(gclient_s, hintForcedString) == 0x36F8, "");
+        static_assert(offsetof(gclient_s, padding) == 0x36FC, "");
+
+        struct __declspec(align(128)) clientActive_t
+        {
+            bool usingAds;
+            int timeoutcount;
+            clSnapshot_t snap;
+            bool alwaysFalse;
+            int serverTime;
+            int oldServerTime;
+            int oldFrameServerTime;
+            int serverTimeDelta;
+            int oldSnapServerTime;
+            int extrapolatedSnapshot;
+            int newSnapshots;
+            int serverId;
+            char mapname[64];
+            int parseEntitiesIndex;
+            int parseClientsIndex;
+            int mouseDx[2];
+            int mouseDy[2];
+            int mouseIndex;
+            bool stanceHeld;
+            StanceState stance;
+            StanceState stancePosition;
+            int stanceTime;
+            int cgameUserCmdWeapon;
+            int cgameUserCmdOffHandIndex;
+            float cgameFOVSensitivityScale;
+            float cgameMaxPitchSpeed;
+            float cgameMaxYawSpeed;
+            float cgameKickAngles[3];
+            float cgameOrigin[3];
+            float cgameVelocity[3];
+            int cgameBobCycle;
+            int cgameMovementDir;
+            int cgameExtraButtons;
+            int cgamePredictedDataServerTime;
+            float viewangles[3];
+            usercmd_s cmds[128];
+            int cmdNumber;
+            ClientArchiveData clientArchive[256];
+            int clientArchiveIndex;
+            int packetBackupCount;
+            int packetBackupMask;
+            int parseEntitiesCount;
+            int parseClientsCount;
+            outPacket_t* outPackets;
+            clSnapshot_t* snapshots;
+            entityState_s* parseEntities;
+            clientState_s* parseClients;
+            int corruptedTranslationFile;
+            char translationVersion[256];
+        };
+        static_assert(sizeof(clientActive_t) == 27904, "");
+
+        enum connstate_t : __int32
+        {
+            CA_DISCONNECTED = 0x0,
+            CA_CINEMATIC = 0x1,
+            CA_LOGO = 0x2,
+            CA_CONNECTING = 0x3,
+            CA_CHALLENGING = 0x4,
+            CA_CONNECTED = 0x5,
+            CA_SENDINGSTATS = 0x6,
+            CA_LOADING = 0x7,
+            CA_PRIMED = 0x8,
+            CA_ACTIVE = 0x9,
+        };
+
+        struct clientUIActive_t
+        {
+            bool active;
+            bool isRunning;
+            bool cgameInitialized;        // 0x002 - v7[2] = 1 in retail
+            bool cgameInitCalled;         // 0x003 - v7[3] = 1 in retail
+            char pad_4[2876];             // 0x004 - padding to reach keyCatchers
+            int keyCatchers;              // 0xB40 - dword_825A6458[804*a1] in retail
+            int displayHUDWithKeycatchUI; // 0xB44
+            connstate_t connectionState;  // 0xB48 - dword_825A6460[804*a1] in retail
+            char pad_B4C[324];            // 0xB4C - padding to reach struct size
+        };
+
+        static_assert(sizeof(clientUIActive_t) == 0xC90, "");                    // 3216 bytes
+        static_assert(offsetof(clientUIActive_t, keyCatchers) == 0xB40, "");     // 2880 bytes
+        static_assert(offsetof(clientUIActive_t, connectionState) == 0xB48, ""); // 2888 bytes
+
+        enum keyNum_t : __int32
+        {
+            K_NONE = 0x0,
+            K_TAB = 0x9,
+            K_ENTER = 0xD,
+            K_ESCAPE = 0x1B,
+            K_SPACE = 0x20,
+            K_BACKSPACE = 0x7F,
+            K_CAPSLOCK = 0x97,
+            K_PAUSE = 0x99,
+            K_UPARROW = 0x9A,
+            K_DOWNARROW = 0x9B,
+            K_LEFTARROW = 0x9C,
+            K_RIGHTARROW = 0x9D,
+            K_ALT = 0x9E,
+            K_CTRL = 0x9F,
+            K_SHIFT = 0xA0,
+            K_INS = 0xA1,
+            K_DEL = 0xA2,
+            K_PGDN = 0xA3,
+            K_PGUP = 0xA4,
+            K_HOME = 0xA5,
+            K_END = 0xA6,
+            K_F1 = 0xA7,
+            K_F2 = 0xA8,
+            K_F3 = 0xA9,
+            K_F4 = 0xAA,
+            K_F5 = 0xAB,
+            K_F6 = 0xAC,
+            K_F7 = 0xAD,
+            K_F8 = 0xAE,
+            K_F9 = 0xAF,
+            K_F10 = 0xB0,
+            K_F11 = 0xB1,
+            K_F12 = 0xB2,
+            K_KP_HOME = 0xB6,
+            K_KP_UPARROW = 0xB7,
+            K_KP_PGUP = 0xB8,
+            K_KP_LEFTARROW = 0xB9,
+            K_KP_5 = 0xBA,
+            K_KP_RIGHTARROW = 0xBB,
+            K_KP_END = 0xBC,
+            K_KP_DOWNARROW = 0xBD,
+            K_KP_PGDN = 0xBE,
+            K_KP_ENTER = 0xBF,
+            K_KP_INS = 0xC0,
+            K_KP_DEL = 0xC1,
+            K_KP_SLASH = 0xC2,
+            K_KP_MINUS = 0xC3,
+            K_KP_PLUS = 0xC4,
+            K_KP_NUMLOCK = 0xC5,
+            K_KP_STAR = 0xC6,
+            K_KP_EQUALS = 0xC7,
+        };
+
+        struct field_t
+        {
+            int cursor;
+            int scroll;
+            int drawWidth;
+            int widthInPixels;
+            float charHeight;
+            int fixedSize;
+            char buffer[256];
+        };
+
+        static_assert(sizeof(field_t) == 0x118, "");
+        static_assert(offsetof(field_t, buffer) == 0x18, "");
+
+        enum LocSelInputState : __int32
+        {
+            LOC_SEL_INPUT_NONE = 0x0,
+            LOC_SEL_INPUT_CONFIRM = 0x1,
+            LOC_SEL_INPUT_CANCEL = 0x2,
+        };
+
+        struct KeyState
+        {
+            int down;
+            int repeats;
+            const char* binding;
+        };
+
+        static_assert(sizeof(KeyState) == 0xC, "");
+
+        struct PlayerKeyState
+        {
+            field_t chatField;
+            int chat_team;
+            int overstrikeMode;
+            int anyKeyDown;
+            KeyState keys[256];
+            LocSelInputState locSelInputState;
+        };
+
+        static_assert(sizeof(PlayerKeyState) == 0xD28, "");
+        static_assert(offsetof(PlayerKeyState, keys) == 0x124, "");
+
+        struct MessageLine
+        {
+            int messageIndex;
+            int textBufPos;
+            int textBufSize;
+            int typingStartTime;
+            int lastTypingSoundTime;
+            int flags;
+        };
+
+        static_assert(sizeof(MessageLine) == 0x18, "");
+
+        struct Message
+        {
+            int startTime;
+            int endTime;
+        };
+
+        static_assert(sizeof(Message) == 0x8, "");
+
+        struct MessageWindow
+        {
+            MessageLine* lines;
+            Message* messages;
+            char* circularTextBuffer;
+            int textBufSize;
+            int lineCount;
+            int padding;
+            int scrollTime;
+            int fadeIn;
+            int fadeOut;
+            int textBufPos;
+            int firstLineIndex;
+            int activeLineCount;
+            int messageIndex;
+        };
+
+        static_assert(sizeof(MessageWindow) == 0x34, "");
+
+        struct MessageBuffer
+        {
+            char gamemsgText[4][2048];
+            MessageWindow gamemsgWindows[4];
+            MessageLine gamemsgLines[4][12];
+            Message gamemsgMessages[4][12];
+            char miniconText[4096];
+            MessageWindow miniconWindow;
+            MessageLine miniconLines[100];
+            Message miniconMessages[100];
+            char errorText[1024];
+            MessageWindow errorWindow;
+            MessageLine errorLines[5];
+            Message errorMessages[5];
+        };
+
+        static_assert(sizeof(MessageBuffer) == 0x4858, "");
+        static_assert(offsetof(MessageBuffer, miniconText) == 0x26D0, "");
+        static_assert(offsetof(MessageBuffer, errorText) == 0x4384, "");
+
+        struct Console
+        {
+            MessageWindow consoleWindow;
+            MessageLine consoleLines[1024];
+            Message consoleMessages[1024];
+            char consoleText[32768];
+            char textTempLine[512];
+            unsigned int lineOffset;
+            int displayLineOffset;
+            int prevChannel;
+            bool outputVisible;
+            int fontHeight;
+            int visibleLineCount;
+            int visiblePixelWidth;
+            float screenMin[2];
+            float screenMax[2];
+            MessageBuffer messageBuffer[4];
+            float color[4];
+        };
+
+        static_assert(sizeof(Console) == 0x223D0, "");
+        static_assert(offsetof(Console, consoleLines) == 0x34, "");
+        static_assert(offsetof(Console, consoleMessages) == 0x6034, "");
+        static_assert(offsetof(Console, consoleText) == 0x8034, "");
+        static_assert(offsetof(Console, textTempLine) == 0x10034, "");
+        static_assert(offsetof(Console, lineOffset) == 0x10234, "");
+        static_assert(offsetof(Console, displayLineOffset) == 0x10238, "");
+        static_assert(offsetof(Console, outputVisible) == 0x10240, "");
+        static_assert(offsetof(Console, fontHeight) == 0x10244, "");
+        static_assert(offsetof(Console, visibleLineCount) == 0x10248, "");
+        static_assert(offsetof(Console, messageBuffer) == 0x10260, "");
+        static_assert(offsetof(Console, color) == 0x223C0, "");
+
+        struct __declspec(align(128)) cg_s
+        {
+            playerState_s predictedPlayerState;
+            char padding[1027200];
+        };
+        static_assert(sizeof(cg_s) == 1039872, "");
+
+        typedef void (*BuiltinFunction)();
+        typedef void (*BuiltinMethod)(scr_entref_t);
+
+        enum scr_builtin_type_t : __int32
+        {
+            BUILTIN_ANY = 0x0,
+            BUILTIN_DEVELOPER_ONLY = 0x1,
+        };
+        static_assert(sizeof(scr_builtin_type_t) == 4, "");
+
+        struct BuiltinFunctionDef
+        {
+            const char* actionString;
+            BuiltinFunction actionFunc;
+            scr_builtin_type_t type;
+        };
+
+        struct BuiltinMethodDef
+        {
+            const char* actionString;
+            BuiltinMethod actionFunc;
+            scr_builtin_type_t type;
+        };
+
+        enum fieldtype_t : __int32
+        {
+            F_INT = 0x0,
+            F_SHORT = 0x1,
+            F_BYTE = 0x2,
+            F_FLOAT = 0x3,
+            F_CSTRING = 0x4,
+            F_STRING = 0x5,
+            F_VECTOR = 0x6,
+            F_ENTITY = 0x7,
+            F_ENTHANDLE = 0x8,
+            F_ANGLES_YAW = 0x9,
+            F_OBJECT = 0xA,
+            F_MODEL = 0xB,
+        };
+
+        struct client_fields_s
+        {
+            const char* name;
+            int ofs;
+            fieldtype_t type;
+            void (*setter)(gclient_s*, const client_fields_s*);
+            void (*getter)(gclient_s*, const client_fields_s*);
+        };
+
+        struct Font_s;
+        struct Material;
+
+        struct CachedAssets_t
+        {
+            Material* scrollBarArrowUp;
+            Material* scrollBarArrowDown;
+            Material* scrollBarArrowLeft;
+            Material* scrollBarArrowRight;
+            Material* scrollBar;
+            Material* scrollBarThumb;
+            Material* sliderBar;
+            Material* sliderThumb;
+            Material* whiteMaterial;
+            Material* cursor;
+            Material* textDecodeCharacters;
+            Material* textDecodeCharactersGlow;
+            Font_s* bigFont;
+            Font_s* smallFont;
+            Font_s* consoleFont;
+            Font_s* boldFont;
+            Font_s* textFont;
+            Font_s* extraBigFont;
+            Font_s* objectiveFont;
+            Font_s* hudBigFont;
+            Font_s* hudSmallFont;
+        };
+
+        struct __declspec(align(4)) sharedUiInfo_t
+        {
+            CachedAssets_t assets;
+            bool preventPause;
+        };
+
+        struct ScreenPlacement
+        {
+            float scaleVirtualToReal[2];
+            float scaleVirtualToFull[2];
+            float scaleRealToVirtual[2];
+            float realViewportPosition[2];
+            float realViewportSize[2];
+            float virtualViewableMin[2];
+            float virtualViewableMax[2];
+            float realViewableMin[2];
+            float realViewableMax[2];
+            float virtualAdjustableMin[2];
+            float virtualAdjustableMax[2];
+            float realAdjustableMin[2];
+            float realAdjustableMax[2];
+            float subScreenLeft;
+        };
+
+        enum XAssetType : __int32
+        {
+            ASSET_TYPE_PHYSPRESET = 0x0,
+            ASSET_TYPE_PHYSCOLLMAP = 0x1,
+            ASSET_TYPE_XANIMPARTS = 0x2,
+            ASSET_TYPE_XMODEL_SURFS = 0x3,
+            ASSET_TYPE_XMODEL = 0x4,
+            ASSET_TYPE_MATERIAL = 0x5,
+            ASSET_TYPE_PIXELSHADER = 0x6,
+            ASSET_TYPE_TECHNIQUE_SET = 0x7,
+            ASSET_TYPE_IMAGE = 0x8,
+            ASSET_TYPE_SOUND = 0x9,
+            ASSET_TYPE_SOUND_CURVE = 0xA,
+            ASSET_TYPE_LOADED_SOUND = 0xB,
+            ASSET_TYPE_CLIPMAP_SP = 0xC,
+            ASSET_TYPE_CLIPMAP_MP = 0xD,
+            ASSET_TYPE_COMWORLD = 0xE,
+            ASSET_TYPE_GAMEWORLD_SP = 0xF,
+            ASSET_TYPE_GAMEWORLD_MP = 0x10,
+            ASSET_TYPE_MAP_ENTS = 0x11,
+            ASSET_TYPE_FXWORLD = 0x12,
+            ASSET_TYPE_GFXWORLD = 0x13,
+            ASSET_TYPE_LIGHT_DEF = 0x14,
+            ASSET_TYPE_UI_MAP = 0x15,
+            ASSET_TYPE_FONT = 0x16,
+            ASSET_TYPE_MENULIST = 0x17,
+            ASSET_TYPE_MENU = 0x18,
+            ASSET_TYPE_LOCALIZE_ENTRY = 0x19,
+            ASSET_TYPE_WEAPON = 0x1A,
+            ASSET_TYPE_SNDDRIVER_GLOBALS = 0x1B,
+            ASSET_TYPE_FX = 0x1C,
+            ASSET_TYPE_IMPACT_FX = 0x1D,
+            ASSET_TYPE_AITYPE = 0x1E,
+            ASSET_TYPE_MPTYPE = 0x1F,
+            ASSET_TYPE_CHARACTER = 0x20,
+            ASSET_TYPE_XMODELALIAS = 0x21,
+            ASSET_TYPE_RAWFILE = 0x22,
+            ASSET_TYPE_STRINGTABLE = 0x23,
+            ASSET_TYPE_LEADERBOARD = 0x24,
+            ASSET_TYPE_STRUCTURED_DATA_DEF = 0x25,
+            ASSET_TYPE_TRACER = 0x26,
+            ASSET_TYPE_VEHICLE = 0x27,
+            ASSET_TYPE_ADDON_MAP_ENTS = 0x28,
+            ASSET_TYPE_COUNT = 0x29,
+            ASSET_TYPE_STRING = 0x29,
+            ASSET_TYPE_ASSETLIST = 0x2A,
+        };
+
+        struct cplane_s;
+        struct cStaticModel_s;
+        struct ClipMaterial
+        {
+            const char* name;
+            int surfaceFlags;
+            int contentFlags;
+        };
+        struct cbrushside_t;
+        struct cNode_t;
+        struct cLeaf_t;
+        struct cLeafBrushNode_s;
+        struct CollisionBorder;
+        struct CollisionPartition;
+        struct CollisionAabbTree;
+        struct cmodel_t;
+        struct cbrush_t;
+
+        struct TriggerModel
+        {
+            int contents;
+            unsigned __int16 hullCount;
+            unsigned __int16 firstHull;
+        };
+
+        struct TriggerHull
+        {
+            Bounds bounds;
+            int contents;
+            unsigned __int16 slabCount;
+            unsigned __int16 firstSlab;
+        };
+
+        struct TriggerSlab
+        {
+            float dir[3];
+            float midPoint;
+            float halfSize;
+        };
+
+        struct MapTriggers
+        {
+            unsigned int count;
+            TriggerModel* models;
+            unsigned int hullCount;
+            TriggerHull* hulls;
+            unsigned int slabCount;
+            TriggerSlab* slabs;
+        };
+
+        struct __declspec(align(2)) Stage
+        {
+            const char* name;
+            float origin[3];
+            unsigned __int16 triggerIndex;
+            unsigned __int8 sunPrimaryLightIndex;
+        };
+
+        struct __declspec(align(4)) MapEnts
+        {
+            const char* name;
+            char* entityString;
+            int numEntityChars;
+            MapTriggers trigger;
+            Stage* stages;
+            unsigned __int8 stageCount;
+        };
+
+        struct SModelAabbNode;
+        struct DynEntityDef;
+        struct DynEntityPose;
+        struct DynEntityClient;
+        struct DynEntityColl;
+
+        struct __declspec(align(64)) clipMap_t
+        {
+            const char* name;
+            int isInUse;
+            int planeCount;
+            cplane_s* planes;
+            unsigned int numStaticModels;
+            cStaticModel_s* staticModelList;
+            unsigned int numMaterials;
+            ClipMaterial* materials;
+            unsigned int numBrushSides;
+            cbrushside_t* brushsides;
+            unsigned int numBrushEdges;
+            unsigned __int8* brushEdges;
+            unsigned int numNodes;
+            cNode_t* nodes;
+            unsigned int numLeafs;
+            cLeaf_t* leafs;
+            unsigned int leafbrushNodesCount;
+            cLeafBrushNode_s* leafbrushNodes;
+            unsigned int numLeafBrushes;
+            unsigned __int16* leafbrushes;
+            unsigned int numLeafSurfaces;
+            unsigned int* leafsurfaces;
+            unsigned int vertCount;
+            float(*verts)[3];
+            int triCount;
+            unsigned __int16* triIndices;
+            unsigned __int8* triEdgeIsWalkable;
+            int borderCount;
+            CollisionBorder* borders;
+            int partitionCount;
+            CollisionPartition* partitions;
+            int aabbTreeCount;
+            CollisionAabbTree* aabbTrees;
+            unsigned int numSubModels;
+            cmodel_t* cmodels;
+            unsigned __int16 numBrushes;
+            cbrush_t* brushes;
+            Bounds* brushBounds;
+            int* brushContents;
+            MapEnts* mapEnts;
+            unsigned __int16 smodelNodeCount;
+            SModelAabbNode* smodelNodes;
+            unsigned __int16 dynEntCount[2];
+            DynEntityDef* dynEntDefList[2];
+            DynEntityPose* dynEntPoseList[2];
+            DynEntityClient* dynEntClientList[2];
+            DynEntityColl* dynEntCollList[2];
+            unsigned int checksum;
+        };
+
+        struct pathnode_t;
+        struct pathbasenode_t;
+        struct pathnode_tree_t;
+        struct VehicleTrackSegment;
+        struct G_GlassData;
+
+        struct PathData
+        {
+            unsigned int nodeCount;
+            pathnode_t* nodes;
+            pathbasenode_t* basenodes;
+            unsigned int chainNodeCount;
+            unsigned __int16* chainNodeForNode;
+            unsigned __int16* nodeForChainNode;
+            int visBytes;
+            unsigned __int8* pathVis;
+            int nodeTreeCount;
+            pathnode_tree_t* nodeTree;
+        };
+
+        struct VehicleTrack
+        {
+            VehicleTrackSegment* segments;
+            unsigned int segmentCount;
+        };
+
+        struct GameWorldSp
+        {
+            const char* name;
+            PathData path;
+            VehicleTrack vehicleTrack;
+            G_GlassData* g_glassData;
+        };
+
+        struct GameWorldMp
+        {
+            const char* name;
+            G_GlassData* g_glassData;
+        };
+
+        struct RawFile
+        {
+            const char* name;
+            int compressedLen;
+            int len;
+            const char* buffer;
+        };
+
+        struct StringTableCell
+        {
+            const char* string;
+            int hash;
+        };
+
+        static_assert(sizeof(StringTableCell) == 8, "");
+        static_assert(offsetof(StringTableCell, string) == 0x0, "");
+        static_assert(offsetof(StringTableCell, hash) == 0x4, "");
+
+        struct StringTable
+        {
+            const char* name;
+            int columnCount;
+            int rowCount;
+            StringTableCell* values;
+        };
+
+        static_assert(sizeof(StringTable) == 16, "");
+        static_assert(offsetof(StringTable, name) == 0x0, "");
+        static_assert(offsetof(StringTable, columnCount) == 0x4, "");
+        static_assert(offsetof(StringTable, rowCount) == 0x8, "");
+        static_assert(offsetof(StringTable, values) == 0xC, "");
+
+        union XAssetHeader
+        {
+            clipMap_t* clipMap;
+            GameWorldSp* gameWorldSp;
+            GameWorldMp* gameWorldMp;
+            MapEnts* mapEnts;
+            RawFile* rawfile;
+            StringTable* stringTable;
+            void* data;
+        };
+
+        struct XAsset
+        {
+            XAssetType type;
+            XAssetHeader header;
+        };
+
+        struct __declspec(align(4)) XAssetEntry
+        {
+            XAsset asset;
+            unsigned __int8 zoneIndex;
+            volatile unsigned __int8 inuseMask;
+            bool printedMissingAsset;
+            unsigned __int16 nextHash;
+            unsigned __int16 nextOverride;
+        };
+
+        union XAssetEntryPoolEntry
+        {
+            XAssetEntry entry;
+            XAssetEntryPoolEntry* next;
+        };
+
+        static_assert(sizeof(XAssetEntry) == 0x10, "");
+        static_assert(offsetof(XAssetEntry, nextHash) == 0xC, "");
+        static_assert(offsetof(XAssetEntry, nextOverride) == 0xE, "");
+
+        // bg_removeBarriers - some items like PMF are ripped from iw4x.
+        enum
+        {
+            PMF_PRONE = 1 << 0,
+            PMF_DUCKED = 1 << 1,
+            PMF_MANTLE = 1 << 2,
+            PMF_LADDER = 1 << 3,
+            PMF_SIGHT_AIMING = 1 << 4,
+            PMF_BACKWARDS_RUN = 1 << 5,
+            PMF_WALKING = 1 << 6,
+            PMF_TIME_HARDLANDING = 1 << 7,
+            PMF_TIME_KNOCKBACK = 1 << 8,
+            PMF_PRONEMOVE_OVERRIDDEN = 1 << 9,
+            PMF_RESPAWNED = 1 << 10,
+            PMF_FROZEN = 1 << 11,
+            PMF_LADDER_FALL = 1 << 12,
+            PMF_JUMPING = 1 << 13,
+            PMF_SPRINTING = 1 << 14,
+            PMF_SHELLSHOCKED = 1 << 15,
+            PMF_MELEE_CHARGE = 1 << 16,
+            PMF_NO_SPRINT = 1 << 17,
+            PMF_NO_JUMP = 1 << 18,
+            PMF_REMOTE_CONTROLLING = 1 << 19,
+            PMF_ANIM_SCRIPTED = 1 << 20,
+            PMF_UNK1 = 1 << 21,
+            PMF_DIVING = 1 << 22,
+        };
+
+        enum TraceHitType : __int32
+        {
+            TRACE_HITTYPE_NONE = 0x0,
+            TRACE_HITTYPE_ENTITY = 0x1,
+            TRACE_HITTYPE_DYNENT_MODEL = 0x2,
+            TRACE_HITTYPE_DYNENT_BRUSH = 0x3,
+            TRACE_HITTYPE_GLASS = 0x4,
+        };
+
+        struct __declspec(align(4)) trace_t
+        {
+            float fraction;
+            float normal[3];
+            int surfaceFlags;
+            int contents;
+            const char* material;
+            TraceHitType hitType;
+            unsigned __int16 hitId;
+            float fractionForHitType;
+            unsigned __int16 modelIndex;
+            unsigned __int16 partName;
+            unsigned __int16 partGroup;
+            bool allsolid;
+            bool startsolid;
+            bool walkable;
+        };
+
+        struct pml_t
+        {
+            float forward[3];
+            float right[3];
+            float up[3];
+            float frametime;
+            int msec;
+            int walking;
+            int groundPlane;
+            int almostGroundPlane;
+            trace_t groundTrace;
+            float impactSpeed;
+            float previous_origin[3];
+            float previous_velocity[3];
+            unsigned int holdrand;
+        };
+
+        struct pmove_t
+        {
+            playerState_s* ps;
+            usercmd_s cmd;
+            usercmd_s oldcmd;
+            int tracemask;
+            int numtouch;
+            int touchents[32];
+            Bounds bounds;
+            float xyspeed;
+            int proneChange;
+            float maxSprintTimeMultiplier;
+            bool mantleStarted;
+            float mantleEndPos[3];
+            int mantleDuration;
+            int viewChangeTime;
+            float viewChange;
+            float fTorsoPitch;
+            float fWaistPitch;
+            unsigned __int8 handler;
+        };
+
+    } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/symbols.h
+++ b/src/game/iw4/mp_tu6/symbols.h
@@ -4,321 +4,328 @@
 
 namespace iw4
 {
-namespace mp_tu6
-{
+    namespace mp_tu6
+    {
 #define IW4_MAX_CLIENTS 18
 #define IW4_ANGLE2SHORT(x) ((int)((x) * 65536 / 360) & 65535)
 
-enum
-{
-    IW4_PITCH = 0,
-    IW4_YAW = 1,
-    IW4_ROLL = 2,
-};
+        enum
+        {
+            IW4_PITCH = 0,
+            IW4_YAW = 1,
+            IW4_ROLL = 2,
+        };
 
-// Functions
-static auto Hunk_AllocateTempMemoryHighInternal = reinterpret_cast<void *(*)(int size)>(0x822FDF08);
+        // Functions
+        static auto Hunk_AllocateTempMemoryHighInternal = reinterpret_cast<void* (*)(int size)>(0x822FDF08);
 
-static auto Cbuf_AddText = reinterpret_cast<void (*)(int localClientNum, const char *text)>(0x82275C60);
+        static auto Cbuf_AddText = reinterpret_cast<void (*)(int localClientNum, const char* text)>(0x82275C60);
 
-typedef void (*ClientCommand_t)(int clientNum);
-static ClientCommand_t ClientCommand = reinterpret_cast<ClientCommand_t>(0x822266D0);
+        typedef void (*ClientCommand_t)(int clientNum);
+        static ClientCommand_t ClientCommand = reinterpret_cast<ClientCommand_t>(0x822266D0);
 
-typedef void (*CL_CharEvent_t)(int localClientNum, int key);
-static CL_CharEvent_t CL_CharEvent = reinterpret_cast<CL_CharEvent_t>(0x82182EC8);
+        typedef void (*CL_CharEvent_t)(int localClientNum, int key);
+        static CL_CharEvent_t CL_CharEvent = reinterpret_cast<CL_CharEvent_t>(0x82182EC8);
 
-typedef void (*CL_ConsoleCharEvent_t)(int localClientNum, int key);
-static CL_ConsoleCharEvent_t CL_ConsoleCharEvent = reinterpret_cast<CL_ConsoleCharEvent_t>(0x82182E60);
+        typedef void (*CL_ConsoleCharEvent_t)(int localClientNum, int key);
+        static CL_ConsoleCharEvent_t CL_ConsoleCharEvent = reinterpret_cast<CL_ConsoleCharEvent_t>(0x82182E60);
 
-typedef void (*CL_ConsolePrint_t)(int localClientNum, int channel, const char *txt, unsigned int duration,
-                                  unsigned int pixelWidth, int flags);
-static CL_ConsolePrint_t CL_ConsolePrint = reinterpret_cast<CL_ConsolePrint_t>(0x821754B8);
+        typedef void (*CL_ConsolePrint_t)(int localClientNum, int channel, const char* txt, unsigned int duration,
+            unsigned int pixelWidth, int flags);
+        static CL_ConsolePrint_t CL_ConsolePrint = reinterpret_cast<CL_ConsolePrint_t>(0x821754B8);
 
-typedef void (*CL_KeyEvent_t)(int localClientNum, int key, int down, unsigned int time);
-static CL_KeyEvent_t CL_KeyEvent = reinterpret_cast<CL_KeyEvent_t>(0x821826F8);
+        typedef void (*CL_KeyEvent_t)(int localClientNum, int key, int down, unsigned int time);
+        static CL_KeyEvent_t CL_KeyEvent = reinterpret_cast<CL_KeyEvent_t>(0x821826F8);
 
-static auto CG_DrawActive = reinterpret_cast<void (*)(int localClientNum)>(0x82129270);
-static auto CG_GameMessage = reinterpret_cast<void (*)(int localClientNum, const char *msg)>(0x8213DE38);
+        static auto CG_DrawActive = reinterpret_cast<void (*)(int localClientNum)>(0x82129270);
+        static auto CG_GameMessage = reinterpret_cast<void (*)(int localClientNum, const char* msg)>(0x8213DE38);
 
-static auto Cmd_AddCommandInternal =
-    reinterpret_cast<void (*)(const char *cmdName, void (*function)(), cmd_function_s *allocedCmd)>(0x82276758);
+        static auto Cmd_AddCommandInternal =
+            reinterpret_cast<void (*)(const char* cmdName, void (*function)(), cmd_function_s * allocedCmd)>(0x82276758);
 
-typedef void (*Cmd_ExecuteSingleCommand_t)(int localClientNum, int controllerIndex, const char *text);
-static Cmd_ExecuteSingleCommand_t Cmd_ExecuteSingleCommand = reinterpret_cast<Cmd_ExecuteSingleCommand_t>(0x82277928);
+        typedef void (*Cmd_ExecuteSingleCommand_t)(int localClientNum, int controllerIndex, const char* text);
+        static Cmd_ExecuteSingleCommand_t Cmd_ExecuteSingleCommand = reinterpret_cast<Cmd_ExecuteSingleCommand_t>(0x82277928);
 
-static auto Cmd_Init = reinterpret_cast<void (*)()>(0x82278048);
+        static auto Cmd_Init = reinterpret_cast<void (*)()>(0x82278048);
 
-static auto Com_InitDvars = reinterpret_cast<void (*)()>(0x822804F8);
+        static auto Com_InitDvars = reinterpret_cast<void (*)()>(0x822804F8);
 
-typedef int (*Com_sprintf_t)(char *dest, unsigned int size, const char *fmt, ...);
-static Com_sprintf_t Com_sprintf = reinterpret_cast<Com_sprintf_t>(0x82315F20);
+        typedef int (*Com_sprintf_t)(char* dest, unsigned int size, const char* fmt, ...);
+        static Com_sprintf_t Com_sprintf = reinterpret_cast<Com_sprintf_t>(0x82315F20);
 
-typedef void (*Com_Printf_t)(int channel, const char *fmt, ...);
-static Com_Printf_t Com_Printf = reinterpret_cast<Com_Printf_t>(0x8227F448);
+        typedef void (*Com_Printf_t)(int channel, const char* fmt, ...);
+        static Com_Printf_t Com_Printf = reinterpret_cast<Com_Printf_t>(0x8227F448);
 
-typedef void (*Com_PrintMessage_t)(int channel, const char *msg, int error);
-static Com_PrintMessage_t Com_PrintMessage = reinterpret_cast<Com_PrintMessage_t>(0x8227F370);
+        typedef void (*Com_PrintMessage_t)(int channel, const char* msg, int error);
+        static Com_PrintMessage_t Com_PrintMessage = reinterpret_cast<Com_PrintMessage_t>(0x8227F370);
 
-typedef int (*I_stricmp_t)(const char *s0, const char *s1);
-static I_stricmp_t I_stricmp = reinterpret_cast<I_stricmp_t>(0x82315B70);
+        typedef int (*I_stricmp_t)(const char* s0, const char* s1);
+        static I_stricmp_t I_stricmp = reinterpret_cast<I_stricmp_t>(0x82315B70);
 
-typedef void (*Info_SetValueForKey_t)(char *s, const char *key, const char *value);
-static Info_SetValueForKey_t Info_SetValueForKey = reinterpret_cast<Info_SetValueForKey_t>(0x823167D8);
+        typedef void (*Info_SetValueForKey_t)(char* s, const char* key, const char* value);
+        static Info_SetValueForKey_t Info_SetValueForKey = reinterpret_cast<Info_SetValueForKey_t>(0x823167D8);
 
-typedef char (*Con_AllowAutoCompleteCycling_t)(char allowed);
-static Con_AllowAutoCompleteCycling_t Con_AllowAutoCompleteCycling =
-    reinterpret_cast<Con_AllowAutoCompleteCycling_t>(0x82177090);
+        typedef char (*Con_AllowAutoCompleteCycling_t)(char allowed);
+        static Con_AllowAutoCompleteCycling_t Con_AllowAutoCompleteCycling =
+            reinterpret_cast<Con_AllowAutoCompleteCycling_t>(0x82177090);
 
-typedef void (*Con_Bottom_t)();
-static Con_Bottom_t Con_Bottom = reinterpret_cast<Con_Bottom_t>(0x82177AB8);
+        typedef void (*Con_Bottom_t)();
+        static Con_Bottom_t Con_Bottom = reinterpret_cast<Con_Bottom_t>(0x82177AB8);
 
-typedef int (*Con_CancelAutoComplete_t)();
-static Con_CancelAutoComplete_t Con_CancelAutoComplete = reinterpret_cast<Con_CancelAutoComplete_t>(0x82177038);
+        typedef int (*Con_CancelAutoComplete_t)();
+        static Con_CancelAutoComplete_t Con_CancelAutoComplete = reinterpret_cast<Con_CancelAutoComplete_t>(0x82177038);
 
-typedef void (*Con_Close_t)(int localClientNum);
-static Con_Close_t Con_Close = reinterpret_cast<Con_Close_t>(0x82177AD8);
+        typedef void (*Con_Close_t)(int localClientNum);
+        static Con_Close_t Con_Close = reinterpret_cast<Con_Close_t>(0x82177AD8);
 
-typedef int (*Con_CycleAutoComplete_t)(int step);
-static Con_CycleAutoComplete_t Con_CycleAutoComplete = reinterpret_cast<Con_CycleAutoComplete_t>(0x82176F48);
+        typedef int (*Con_CycleAutoComplete_t)(int step);
+        static Con_CycleAutoComplete_t Con_CycleAutoComplete = reinterpret_cast<Con_CycleAutoComplete_t>(0x82176F48);
 
-typedef void (*Con_Init_t)();
-static Con_Init_t Con_Init = reinterpret_cast<Con_Init_t>(0x821735C0);
+        typedef void (*Con_Init_t)();
+        static Con_Init_t Con_Init = reinterpret_cast<Con_Init_t>(0x821735C0);
 
-typedef int (*Con_IsActive_t)(int localClientNum);
-static Con_IsActive_t Con_IsActive = reinterpret_cast<Con_IsActive_t>(0x82177C38);
+        typedef int (*Con_IsActive_t)(int localClientNum);
+        static Con_IsActive_t Con_IsActive = reinterpret_cast<Con_IsActive_t>(0x82177C38);
 
-typedef void (*Con_PageDown_t)();
-static Con_PageDown_t Con_PageDown = reinterpret_cast<Con_PageDown_t>(0x82177A30);
+        typedef void (*Con_PageDown_t)();
+        static Con_PageDown_t Con_PageDown = reinterpret_cast<Con_PageDown_t>(0x82177A30);
 
-typedef void (*Con_PageUp_t)();
-static Con_PageUp_t Con_PageUp = reinterpret_cast<Con_PageUp_t>(0x821779C8);
+        typedef void (*Con_PageUp_t)();
+        static Con_PageUp_t Con_PageUp = reinterpret_cast<Con_PageUp_t>(0x821779C8);
 
-typedef void (*Con_ToggleConsole_t)();
-static Con_ToggleConsole_t Con_ToggleConsole = reinterpret_cast<Con_ToggleConsole_t>(0x82177D10);
+        typedef void (*Con_ToggleConsole_t)();
+        static Con_ToggleConsole_t Con_ToggleConsole = reinterpret_cast<Con_ToggleConsole_t>(0x82177D10);
 
-typedef void (*Con_ToggleConsoleOutput_t)();
-static Con_ToggleConsoleOutput_t Con_ToggleConsoleOutput = reinterpret_cast<Con_ToggleConsoleOutput_t>(0x82177528);
+        typedef void (*Con_ToggleConsoleOutput_t)();
+        static Con_ToggleConsoleOutput_t Con_ToggleConsoleOutput = reinterpret_cast<Con_ToggleConsoleOutput_t>(0x82177528);
 
-typedef void (*Con_Top_t)();
-static Con_Top_t Con_Top = reinterpret_cast<Con_Top_t>(0x82177A78);
+        typedef void (*Con_Top_t)();
+        static Con_Top_t Con_Top = reinterpret_cast<Con_Top_t>(0x82177A78);
 
-typedef void (*Console_Key_t)(int localClientNum, int key);
-static Console_Key_t Console_Key = reinterpret_cast<Console_Key_t>(0x821821D0);
+        typedef void (*Console_Key_t)(int localClientNum, int key);
+        static Console_Key_t Console_Key = reinterpret_cast<Console_Key_t>(0x821821D0);
 
-static auto DB_LinkXAssetEntry1 =
-    reinterpret_cast<XAssetEntryPoolEntry *(*)(XAssetType type, XAssetHeader *header)>(0x821DE528);
+        static auto DB_LinkXAssetEntry1 =
+            reinterpret_cast<XAssetEntryPoolEntry * (*)(XAssetType type, XAssetHeader * header)>(0x821DE528);
 
-typedef int (*DB_GetXAssetSizeHandlerFunc)();
-static DB_GetXAssetSizeHandlerFunc *DB_GetXAssetSizeHandler =
-    reinterpret_cast<DB_GetXAssetSizeHandlerFunc *>(0x82442490);
+        typedef int (*DB_GetXAssetSizeHandlerFunc)();
+        static DB_GetXAssetSizeHandlerFunc* DB_GetXAssetSizeHandler =
+            reinterpret_cast<DB_GetXAssetSizeHandlerFunc*>(0x82442490);
 
-typedef const char *(*DB_GetXAssetName_t)(const XAsset *asset);
-static DB_GetXAssetName_t DB_GetXAssetName = reinterpret_cast<DB_GetXAssetName_t>(0x821AEFD8);
-
-typedef void (*DB_SetXAssetName_t)(XAsset *asset, const char *name);
-static DB_SetXAssetName_t DB_SetXAssetName = reinterpret_cast<DB_SetXAssetName_t>(0x821AEFF8);
+        typedef const char* (*DB_GetXAssetName_t)(const XAsset* asset);
+        static DB_GetXAssetName_t DB_GetXAssetName = reinterpret_cast<DB_GetXAssetName_t>(0x821AEFD8);
+
+        typedef void (*DB_SetXAssetName_t)(XAsset* asset, const char* name);
+        static DB_SetXAssetName_t DB_SetXAssetName = reinterpret_cast<DB_SetXAssetName_t>(0x821AEFF8);
 
-typedef void (*DB_LoadXFile_t)(XZoneMemory *zoneMem, DBFile *file);
-static DB_LoadXFile_t DB_LoadXFile = reinterpret_cast<DB_LoadXFile_t>(0x821AFCB8);
+        typedef void (*DB_LoadXFile_t)(XZoneMemory* zoneMem, DBFile* file);
+        static DB_LoadXFile_t DB_LoadXFile = reinterpret_cast<DB_LoadXFile_t>(0x821AFCB8);
 
-typedef XAssetHeader (*DB_FindXAssetHeader_t)(XAssetType type, const char *name);
-static DB_FindXAssetHeader_t DB_FindXAssetHeader = reinterpret_cast<DB_FindXAssetHeader_t>(0x821E25B0);
+        typedef XAssetHeader(*DB_FindXAssetHeader_t)(XAssetType type, const char* name);
+        static DB_FindXAssetHeader_t DB_FindXAssetHeader = reinterpret_cast<DB_FindXAssetHeader_t>(0x821E25B0);
 
-typedef dvar_t *(*Dvar_RegisterBool_t)(const char *dvarName, bool value, unsigned __int16 flags,
-                                       const char *description);
-static Dvar_RegisterBool_t Dvar_RegisterBool = reinterpret_cast<Dvar_RegisterBool_t>(0x8230EE00);
+        typedef dvar_t* (*Dvar_RegisterBool_t)(const char* dvarName, bool value, unsigned __int16 flags,
+            const char* description);
+        static Dvar_RegisterBool_t Dvar_RegisterBool = reinterpret_cast<Dvar_RegisterBool_t>(0x8230EE00);
 
-typedef dvar_t *(*Dvar_RegisterFloat_t)(const char *dvarName, double value, double min, double max,
-                                        unsigned __int16 flags, const char *description);
-static Dvar_RegisterFloat_t Dvar_RegisterFloat = reinterpret_cast<Dvar_RegisterFloat_t>(0x8230EE90);
+        typedef dvar_t* (*Dvar_RegisterFloat_t)(const char* dvarName, double value, double min, double max,
+            unsigned __int16 flags, const char* description);
+        static Dvar_RegisterFloat_t Dvar_RegisterFloat = reinterpret_cast<Dvar_RegisterFloat_t>(0x8230EE90);
 
-typedef dvar_t *(*Dvar_RegisterString_t)(const char *dvarName, const char *value, unsigned __int16 flags,
-                                         const char *description);
-static Dvar_RegisterString_t Dvar_RegisterString = reinterpret_cast<Dvar_RegisterString_t>(0x8230F010);
+        typedef dvar_t* (*Dvar_RegisterString_t)(const char* dvarName, const char* value, unsigned __int16 flags,
+            const char* description);
+        static Dvar_RegisterString_t Dvar_RegisterString = reinterpret_cast<Dvar_RegisterString_t>(0x8230F010);
 
-static auto Dvar_SetString = reinterpret_cast<void (*)(const dvar_t *dvar, const char *value)>(0x8230F7D8);
+        static auto Dvar_SetString = reinterpret_cast<void (*)(const dvar_t * dvar, const char* value)>(0x8230F7D8);
 
-typedef void (*Field_AdjustScroll_t)(const ScreenPlacement *scrPlace, field_t *edit);
-static Field_AdjustScroll_t Field_AdjustScroll = reinterpret_cast<Field_AdjustScroll_t>(0x8217FA98);
+        typedef void (*Field_AdjustScroll_t)(const ScreenPlacement* scrPlace, field_t* edit);
+        static Field_AdjustScroll_t Field_AdjustScroll = reinterpret_cast<Field_AdjustScroll_t>(0x8217FA98);
 
-typedef int (*Field_CharEvent_t)(int localClientNum, const ScreenPlacement *scrPlace, field_t *edit, int ch);
-static Field_CharEvent_t Field_CharEvent = reinterpret_cast<Field_CharEvent_t>(0x82182028);
+        typedef int (*Field_CharEvent_t)(int localClientNum, const ScreenPlacement* scrPlace, field_t* edit, int ch);
+        static Field_CharEvent_t Field_CharEvent = reinterpret_cast<Field_CharEvent_t>(0x82182028);
 
-typedef int (*Field_KeyDownEvent_t)(int localClientNum, const ScreenPlacement *scrPlace, field_t *edit, int key);
-static Field_KeyDownEvent_t Field_KeyDownEvent = reinterpret_cast<Field_KeyDownEvent_t>(0x82181DB8);
+        typedef int (*Field_KeyDownEvent_t)(int localClientNum, const ScreenPlacement* scrPlace, field_t* edit, int key);
+        static Field_KeyDownEvent_t Field_KeyDownEvent = reinterpret_cast<Field_KeyDownEvent_t>(0x82181DB8);
 
-typedef int (*Key_AddCatcher_t)(int localClientNum, int orMask);
-static Key_AddCatcher_t Key_AddCatcher = reinterpret_cast<Key_AddCatcher_t>(0x82181AC8);
+        typedef int (*Key_AddCatcher_t)(int localClientNum, int orMask);
+        static Key_AddCatcher_t Key_AddCatcher = reinterpret_cast<Key_AddCatcher_t>(0x82181AC8);
 
-typedef int (*Key_IsCatcherActive_t)(int localClientNum, int mask);
-static Key_IsCatcherActive_t Key_IsCatcherActive = reinterpret_cast<Key_IsCatcherActive_t>(0x82181AA0);
+        typedef int (*Key_IsCatcherActive_t)(int localClientNum, int mask);
+        static Key_IsCatcherActive_t Key_IsCatcherActive = reinterpret_cast<Key_IsCatcherActive_t>(0x82181AA0);
 
-typedef int (*Key_RemoveCatcher_t)(int localClientNum, int andMask);
-static Key_RemoveCatcher_t Key_RemoveCatcher = reinterpret_cast<Key_RemoveCatcher_t>(0x82181AE8);
+        typedef int (*Key_RemoveCatcher_t)(int localClientNum, int andMask);
+        static Key_RemoveCatcher_t Key_RemoveCatcher = reinterpret_cast<Key_RemoveCatcher_t>(0x82181AE8);
 
-typedef int (*Key_SetCatcher_t)(int localClientNum, int catcher);
-static Key_SetCatcher_t Key_SetCatcher = reinterpret_cast<Key_SetCatcher_t>(0x82181B20);
+        typedef int (*Key_SetCatcher_t)(int localClientNum, int catcher);
+        static Key_SetCatcher_t Key_SetCatcher = reinterpret_cast<Key_SetCatcher_t>(0x82181B20);
 
-typedef Material *(*Material_RegisterHandle_t)(const char *name);
-static Material_RegisterHandle_t Material_RegisterHandle = reinterpret_cast<Material_RegisterHandle_t>(0x823C2FF8);
+        typedef Material* (*Material_RegisterHandle_t)(const char* name);
+        static Material_RegisterHandle_t Material_RegisterHandle = reinterpret_cast<Material_RegisterHandle_t>(0x823C2FF8);
 
-static auto R_CheckDvarModified = reinterpret_cast<int (*)(const dvar_t *dvar)>(0x823DDD78);
+        static auto R_CheckDvarModified = reinterpret_cast<int (*)(const dvar_t * dvar)>(0x823DDD78);
 
-typedef void (*R_AddCmdDrawStretchPic_t)(float x, float y, float w, float h, float s0, float t0, float s1, float t1,
-                                         const float *color, Material *material);
-static R_AddCmdDrawStretchPic_t R_AddCmdDrawStretchPic = reinterpret_cast<R_AddCmdDrawStretchPic_t>(0x823C6DB0);
+        typedef void (*R_AddCmdDrawStretchPic_t)(float x, float y, float w, float h, float s0, float t0, float s1, float t1,
+            const float* color, Material* material);
+        static R_AddCmdDrawStretchPic_t R_AddCmdDrawStretchPic = reinterpret_cast<R_AddCmdDrawStretchPic_t>(0x823C6DB0);
 
-typedef void (*R_AddCmdDrawText_t)(const char *text, int maxChars, iw4::mp_tu6::Font_s *font, float x, float y,
-                                   float xScale, float yScale, float rotation, const float *color, int style);
-static R_AddCmdDrawText_t R_AddCmdDrawText = reinterpret_cast<R_AddCmdDrawText_t>(0x823C7690);
+        typedef void (*R_AddCmdDrawText_t)(const char* text, int maxChars, iw4::mp_tu6::Font_s* font, float x, float y,
+            float xScale, float yScale, float rotation, const float* color, int style);
+        static R_AddCmdDrawText_t R_AddCmdDrawText = reinterpret_cast<R_AddCmdDrawText_t>(0x823C7690);
 
-static auto R_RegisterFont = reinterpret_cast<Font_s *(*)(const char *name)>(0x823C2798);
+        static auto R_RegisterFont = reinterpret_cast<Font_s * (*)(const char* name)>(0x823C2798);
 
-typedef int (*R_TextWidth_t)(const char *text, int maxChars, Font_s *font);
-static R_TextWidth_t R_TextWidth = reinterpret_cast<R_TextWidth_t>(0x823C28F8);
+        typedef int (*R_TextWidth_t)(const char* text, int maxChars, Font_s* font);
+        static R_TextWidth_t R_TextWidth = reinterpret_cast<R_TextWidth_t>(0x823C28F8);
 
-static auto Scr_AddSourceBuffer =
-    reinterpret_cast<char *(*)(const char *filename, const char *extFilename)>(0x8229F2C8);
+        static auto Scr_AddSourceBuffer =
+            reinterpret_cast<char* (*)(const char* filename, const char* extFilename)>(0x8229F2C8);
 
-static auto Scr_AddClassField =
-    reinterpret_cast<void (*)(ClassNum classnum, const char *name, unsigned __int16 offset)>(0x822A9B98);
-static auto GScr_AddFieldsForClient = reinterpret_cast<void (*)()>(0x8221B238);
-static auto Scr_SetClientField = reinterpret_cast<void (*)(gclient_s *client, int offset)>(0x8221B290);
-static auto Scr_SetGenericField = reinterpret_cast<void (*)(unsigned __int8 *b, fieldtype_t type, int ofs)>(0x8225A698);
-static auto Scr_GetGenericField = reinterpret_cast<void (*)(unsigned __int8 *b, fieldtype_t type, int ofs)>(0x8225A7B8);
-static auto Scr_GetObjectField = reinterpret_cast<void (*)(ClassNum classnum, int entnum, int offset)>(0x8225ABF0);
+        static auto Scr_AddClassField =
+            reinterpret_cast<void (*)(ClassNum classnum, const char* name, unsigned __int16 offset)>(0x822A9B98);
+        static auto GScr_AddFieldsForClient = reinterpret_cast<void (*)()>(0x8221B238);
+        static auto Scr_SetClientField = reinterpret_cast<void (*)(gclient_s * client, int offset)>(0x8221B290);
+        static auto Scr_SetGenericField = reinterpret_cast<void (*)(unsigned __int8* b, fieldtype_t type, int ofs)>(0x8225A698);
+        static auto Scr_GetGenericField = reinterpret_cast<void (*)(unsigned __int8* b, fieldtype_t type, int ofs)>(0x8225A7B8);
+        static auto Scr_GetObjectField = reinterpret_cast<void (*)(ClassNum classnum, int entnum, int offset)>(0x8225ABF0);
 
-static auto Scr_GetString = reinterpret_cast<const char *(*)(unsigned int index)>(0x822B33A8);
-static auto Scr_AddInt = reinterpret_cast<void (*)(int value)>(0x822ADD18);
-static auto Scr_GetInt = reinterpret_cast<int (*)(unsigned int index)>(0x822B2D70);
-typedef double (*Scr_GetFloat_t)(unsigned int index);
-static Scr_GetFloat_t Scr_GetFloat = reinterpret_cast<Scr_GetFloat_t>(0x822B30D0);
-typedef void (*Scr_AddUndefined_t)();
-static Scr_AddUndefined_t Scr_AddUndefined = reinterpret_cast<Scr_AddUndefined_t>(0x822ADE98);
-typedef void (*Scr_AddString_t)(const char *value);
-static Scr_AddString_t Scr_AddString = reinterpret_cast<Scr_AddString_t>(0x822ADFF0);
-typedef void (*Scr_AddEntity_t)(gentity_s *ent);
-static Scr_AddEntity_t Scr_AddEntity = reinterpret_cast<Scr_AddEntity_t>(0x82259A60);
-static auto Scr_GetVector = reinterpret_cast<void (*)(unsigned int index, float *vectorValue)>(0x822B35B8);
-static auto Scr_Error = reinterpret_cast<void (*)(const char *error)>(0x822AE470);
-static auto GetEntity = reinterpret_cast<gentity_s *(*)(scr_entref_t entref)>(0x8223F4D0);
-typedef gentity_s *(*GetPlayerEntity_t)(scr_entref_t entref);
-static GetPlayerEntity_t GetPlayerEntity = reinterpret_cast<GetPlayerEntity_t>(0x8223F540);
-typedef void (*Scr_ParamError_t)(unsigned int index, const char *error);
-static Scr_ParamError_t Scr_ParamError = reinterpret_cast<Scr_ParamError_t>(0x822AE600);
-static auto Scr_ObjectError = reinterpret_cast<void (*)(const char *error)>(0x822AE668);
+        static auto Scr_GetString = reinterpret_cast<const char* (*)(unsigned int index)>(0x822B33A8);
+        static auto Scr_AddInt = reinterpret_cast<void (*)(int value)>(0x822ADD18);
+        static auto Scr_GetInt = reinterpret_cast<int (*)(unsigned int index)>(0x822B2D70);
+        typedef double (*Scr_GetFloat_t)(unsigned int index);
+        static Scr_GetFloat_t Scr_GetFloat = reinterpret_cast<Scr_GetFloat_t>(0x822B30D0);
+        typedef void (*Scr_AddUndefined_t)();
+        static Scr_AddUndefined_t Scr_AddUndefined = reinterpret_cast<Scr_AddUndefined_t>(0x822ADE98);
+        typedef void (*Scr_AddString_t)(const char* value);
+        static Scr_AddString_t Scr_AddString = reinterpret_cast<Scr_AddString_t>(0x822ADFF0);
+        typedef void (*Scr_AddEntity_t)(gentity_s* ent);
+        static Scr_AddEntity_t Scr_AddEntity = reinterpret_cast<Scr_AddEntity_t>(0x82259A60);
+        static auto Scr_GetVector = reinterpret_cast<void (*)(unsigned int index, float* vectorValue)>(0x822B35B8);
+        static auto Scr_Error = reinterpret_cast<void (*)(const char* error)>(0x822AE470);
+        static auto GetEntity = reinterpret_cast<gentity_s * (*)(scr_entref_t entref)>(0x8223F4D0);
+        typedef gentity_s* (*GetPlayerEntity_t)(scr_entref_t entref);
+        static GetPlayerEntity_t GetPlayerEntity = reinterpret_cast<GetPlayerEntity_t>(0x8223F540);
+        typedef void (*Scr_ParamError_t)(unsigned int index, const char* error);
+        static Scr_ParamError_t Scr_ParamError = reinterpret_cast<Scr_ParamError_t>(0x822AE600);
+        static auto Scr_ObjectError = reinterpret_cast<void (*)(const char* error)>(0x822AE668);
 
-static auto Scr_RegisterFunction = reinterpret_cast<void (*)(int func, const char *name)>(0x822963C0);
+        static auto Scr_RegisterFunction = reinterpret_cast<void (*)(int func, const char* name)>(0x822963C0);
 
-static auto Scr_GetFunction =
-    reinterpret_cast<BuiltinFunction (*)(const char **pName, scr_builtin_type_t *type)>(0x82254C38);
-static auto Scr_GetMethod =
-    reinterpret_cast<BuiltinMethod (*)(const char **pName, scr_builtin_type_t *type)>(0x82254D88);
+        static auto Scr_GetFunction =
+            reinterpret_cast<BuiltinFunction(*)(const char** pName, scr_builtin_type_t * type)>(0x82254C38);
+        static auto Scr_GetMethod =
+            reinterpret_cast<BuiltinMethod(*)(const char** pName, scr_builtin_type_t * type)>(0x82254D88);
 
-static auto Scr_GetNumParam = reinterpret_cast<unsigned int (*)()>(0x822ADC88);
+        static auto Scr_GetNumParam = reinterpret_cast<unsigned int (*)()>(0x822ADC88);
 
-typedef void (*PlayerCmd_GetGuid_t)(scr_entref_t entref);
-static PlayerCmd_GetGuid_t PlayerCmd_GetGuid = reinterpret_cast<PlayerCmd_GetGuid_t>(0x82223C18);
+        typedef void (*PlayerCmd_GetGuid_t)(scr_entref_t entref);
+        static PlayerCmd_GetGuid_t PlayerCmd_GetGuid = reinterpret_cast<PlayerCmd_GetGuid_t>(0x82223C18);
 
-typedef int *(*G_SelectWeaponIndex_t)(int clientNum, int iWeaponIndex);
-static G_SelectWeaponIndex_t G_SelectWeaponIndex = reinterpret_cast<G_SelectWeaponIndex_t>(0x82261410);
+        typedef int* (*G_SelectWeaponIndex_t)(int clientNum, int iWeaponIndex);
+        static G_SelectWeaponIndex_t G_SelectWeaponIndex = reinterpret_cast<G_SelectWeaponIndex_t>(0x82261410);
 
-typedef void (*SV_ClientThink_t)(client_t *cl, usercmd_s *cmd);
-static SV_ClientThink_t SV_ClientThink = reinterpret_cast<SV_ClientThink_t>(0x822BC778);
+        typedef void (*SV_ClientThink_t)(client_t* cl, usercmd_s* cmd);
+        static SV_ClientThink_t SV_ClientThink = reinterpret_cast<SV_ClientThink_t>(0x822BC778);
 
-typedef void (*SV_BotUserMove_t)(client_t *cl);
-static SV_BotUserMove_t SV_BotUserMove = reinterpret_cast<SV_BotUserMove_t>(0x822C3208);
+        typedef void (*SV_BotUserMove_t)(client_t* cl);
+        static SV_BotUserMove_t SV_BotUserMove = reinterpret_cast<SV_BotUserMove_t>(0x822C3208);
 
-typedef void (*SV_CalcPings_t)();
-static SV_CalcPings_t SV_CalcPings = reinterpret_cast<SV_CalcPings_t>(0x822C2910);
+        typedef void (*SV_CalcPings_t)();
+        static SV_CalcPings_t SV_CalcPings = reinterpret_cast<SV_CalcPings_t>(0x822C2910);
 
-typedef BOOL (*SV_IsClientBot_t)(int clientNum);
-static SV_IsClientBot_t SV_IsClientBot = reinterpret_cast<SV_IsClientBot_t>(0x822C3B10);
+        typedef BOOL(*SV_IsClientBot_t)(int clientNum);
+        static SV_IsClientBot_t SV_IsClientBot = reinterpret_cast<SV_IsClientBot_t>(0x822C3B10);
 
-typedef gentity_s *(*SV_AddTestClient_t)();
-static SV_AddTestClient_t SV_AddTestClient = reinterpret_cast<SV_AddTestClient_t>(0x822BDCB8);
+        typedef gentity_s* (*SV_AddTestClient_t)();
+        static SV_AddTestClient_t SV_AddTestClient = reinterpret_cast<SV_AddTestClient_t>(0x822BDCB8);
 
-typedef void (*SV_Cmd_ArgvBuffer_t)(int arg, char *buffer, int bufferLength);
-static SV_Cmd_ArgvBuffer_t SV_Cmd_ArgvBuffer = reinterpret_cast<SV_Cmd_ArgvBuffer_t>(0x822760C8);
+        typedef void (*SV_Cmd_ArgvBuffer_t)(int arg, char* buffer, int bufferLength);
+        static SV_Cmd_ArgvBuffer_t SV_Cmd_ArgvBuffer = reinterpret_cast<SV_Cmd_ArgvBuffer_t>(0x822760C8);
 
-typedef void (*SV_GameSendServerCommand_t)(int clientNum, svscmd_type type, const char *text);
-static SV_GameSendServerCommand_t SV_GameSendServerCommand = reinterpret_cast<SV_GameSendServerCommand_t>(0x822BDF00);
+        typedef void (*SV_GameSendServerCommand_t)(int clientNum, svscmd_type type, const char* text);
+        static SV_GameSendServerCommand_t SV_GameSendServerCommand = reinterpret_cast<SV_GameSendServerCommand_t>(0x822BDF00);
 
-typedef void (*SV_UserinfoChanged_t)(client_t *cl);
-static SV_UserinfoChanged_t SV_UserinfoChanged = reinterpret_cast<SV_UserinfoChanged_t>(0x822BBED8);
+        typedef void (*SV_UserinfoChanged_t)(client_t* cl);
+        static SV_UserinfoChanged_t SV_UserinfoChanged = reinterpret_cast<SV_UserinfoChanged_t>(0x822BBED8);
 
-typedef void (*Scr_ShutdownSystem_t)(unsigned __int8 sys);
-static Scr_ShutdownSystem_t Scr_ShutdownSystem = reinterpret_cast<Scr_ShutdownSystem_t>(0x822A36E8);
+        typedef void (*Scr_ShutdownSystem_t)(unsigned __int8 sys);
+        static Scr_ShutdownSystem_t Scr_ShutdownSystem = reinterpret_cast<Scr_ShutdownSystem_t>(0x822A36E8);
 
-typedef void (*BG_ComputeAndApplyWeaponMovement_IdleAngles_t)(weaponState_t *ws, float *angles);
-static BG_ComputeAndApplyWeaponMovement_IdleAngles_t BG_ComputeAndApplyWeaponMovement_IdleAngles =
-    reinterpret_cast<BG_ComputeAndApplyWeaponMovement_IdleAngles_t>(0x82116638);
+        typedef void (*BG_ComputeAndApplyWeaponMovement_IdleAngles_t)(weaponState_t* ws, float* angles);
+        static BG_ComputeAndApplyWeaponMovement_IdleAngles_t BG_ComputeAndApplyWeaponMovement_IdleAngles =
+            reinterpret_cast<BG_ComputeAndApplyWeaponMovement_IdleAngles_t>(0x82116638);
 
-typedef void (*BG_CalculateViewMovement_Angles_Idle_t)(viewState_t *vs, float *angles);
-static BG_CalculateViewMovement_Angles_Idle_t BG_CalculateViewMovement_Angles_Idle =
-    reinterpret_cast<BG_CalculateViewMovement_Angles_Idle_t>(0x82118198);
+        typedef void (*BG_CalculateViewMovement_Angles_Idle_t)(viewState_t* vs, float* angles);
+        static BG_CalculateViewMovement_Angles_Idle_t BG_CalculateViewMovement_Angles_Idle =
+            reinterpret_cast<BG_CalculateViewMovement_Angles_Idle_t>(0x82118198);
 
-typedef WeaponCompleteDef *(*BG_GetWeaponCompleteDef_t)(unsigned int weaponIndex);
-static BG_GetWeaponCompleteDef_t BG_GetWeaponCompleteDef = reinterpret_cast<BG_GetWeaponCompleteDef_t>(0x821142C0);
+        typedef WeaponCompleteDef* (*BG_GetWeaponCompleteDef_t)(unsigned int weaponIndex);
+        static BG_GetWeaponCompleteDef_t BG_GetWeaponCompleteDef = reinterpret_cast<BG_GetWeaponCompleteDef_t>(0x821142C0);
 
-typedef int (*BG_GetNumWeapons_t)();
-static BG_GetNumWeapons_t BG_GetNumWeapons = reinterpret_cast<BG_GetNumWeapons_t>(0x821143F0);
+        typedef int (*BG_GetNumWeapons_t)();
+        static BG_GetNumWeapons_t BG_GetNumWeapons = reinterpret_cast<BG_GetNumWeapons_t>(0x821143F0);
 
-typedef bool (*BG_PlayerHasWeapon_t)(const playerState_s *ps, unsigned int weaponIndex);
-static BG_PlayerHasWeapon_t BG_PlayerHasWeapon = reinterpret_cast<BG_PlayerHasWeapon_t>(0x820FE5F0);
+        typedef bool (*BG_PlayerHasWeapon_t)(const playerState_s* ps, unsigned int weaponIndex);
+        static BG_PlayerHasWeapon_t BG_PlayerHasWeapon = reinterpret_cast<BG_PlayerHasWeapon_t>(0x820FE5F0);
 
-static auto Weapon_RocketLauncher_Fire =
-    reinterpret_cast<gentity_s *(*)(gentity_s * ent, unsigned int weaponIndex, double spread, weaponParms *wp,
-                                    weaponParms *gunVel, struct lockonFireParms *lockParms,
-                                    lockonFireParms *magicBullet)>(0x82260C90);
+        static auto Weapon_RocketLauncher_Fire =
+            reinterpret_cast<gentity_s * (*)(gentity_s * ent, unsigned int weaponIndex, double spread, weaponParms * wp,
+                weaponParms * gunVel, struct lockonFireParms* lockParms,
+                lockonFireParms * magicBullet)>(0x82260C90);
 
-typedef const ScreenPlacement *(*ScrPlace_GetFullPlacement_t)();
-static ScrPlace_GetFullPlacement_t ScrPlace_GetFullPlacement =
-    reinterpret_cast<ScrPlace_GetFullPlacement_t>(0x821AB790);
+        typedef const ScreenPlacement* (*ScrPlace_GetFullPlacement_t)();
+        static ScrPlace_GetFullPlacement_t ScrPlace_GetFullPlacement =
+            reinterpret_cast<ScrPlace_GetFullPlacement_t>(0x821AB790);
 
-static auto ScrPlace_GetUnsafeFullPlacement = reinterpret_cast<const ScreenPlacement *(*)()>(0x821AB7A0);
+        static auto ScrPlace_GetUnsafeFullPlacement = reinterpret_cast<const ScreenPlacement * (*)()>(0x821AB7A0);
 
-static auto SCR_DrawScreenField = reinterpret_cast<void (*)(int localClientNum, int refreshedUI)>(0x8218E800);
+        static auto SCR_DrawScreenField = reinterpret_cast<void (*)(int localClientNum, int refreshedUI)>(0x8218E800);
 
-typedef unsigned int (*Sys_Milliseconds_t)();
-static Sys_Milliseconds_t Sys_Milliseconds = reinterpret_cast<Sys_Milliseconds_t>(0x823401C8);
+        typedef unsigned int (*Sys_Milliseconds_t)();
+        static Sys_Milliseconds_t Sys_Milliseconds = reinterpret_cast<Sys_Milliseconds_t>(0x823401C8);
 
-static auto UI_DrawBuildNumber = reinterpret_cast<void (*)(int localClientNum)>(0x822DAC70);
-static auto UI_DrawText =
-    reinterpret_cast<void (*)(const ScreenPlacement *scrPlace, const char *text, int maxChars, Font_s *font, double x,
-                              double y, int horzAlign, int vertAlign, double scale, const float *color, int style)>(
-        0x822DA678);
-// static auto UI_RefreshViewport = reinterpret_cast<void (*)(int localClientNum)>(0x822E4100);
+        static auto UI_DrawBuildNumber = reinterpret_cast<void (*)(int localClientNum)>(0x822DAC70);
+        static auto UI_DrawText =
+            reinterpret_cast<void (*)(const ScreenPlacement * scrPlace, const char* text, int maxChars, Font_s * font, double x,
+                double y, int horzAlign, int vertAlign, double scale, const float* color, int style)>(
+                    0x822DA678);
+        // static auto UI_RefreshViewport = reinterpret_cast<void (*)(int localClientNum)>(0x822E4100);
 
-static auto va = reinterpret_cast<char *(*)(const char *format, ...)>(0x823160A8);
+        static auto va = reinterpret_cast<char* (*)(const char* format, ...)>(0x823160A8);
 
-// Data
-static auto DB_XAssetPool = reinterpret_cast<void **>(0x82442828);
-static auto g_assetNames = reinterpret_cast<const char **>(0x82442298);
-static auto g_poolSize = reinterpret_cast<int *>(0x82442588);
-static auto g_load = reinterpret_cast<const DB_LoadData *>(0x82678600);
-static auto g_zoneIndex = reinterpret_cast<const unsigned int *>(0x827ADAE4);
-static auto g_zones = reinterpret_cast<const XZone *>(0x829D8048);
-static auto g_assetEntryPool = reinterpret_cast<const XAssetEntryPoolEntry *>(0x82839700);
-static auto gameWorldMp = reinterpret_cast<GameWorldMp *>(0x82DFD010);
+        // Data
+        static auto DB_XAssetPool = reinterpret_cast<void**>(0x82442828);
+        static auto g_assetNames = reinterpret_cast<const char**>(0x82442298);
+        static auto g_poolSize = reinterpret_cast<int*>(0x82442588);
+        static auto g_load = reinterpret_cast<const DB_LoadData*>(0x82678600);
+        static auto g_zoneIndex = reinterpret_cast<const unsigned int*>(0x827ADAE4);
+        static auto g_zones = reinterpret_cast<const XZone*>(0x829D8048);
+        static auto g_assetEntryPool = reinterpret_cast<const XAssetEntryPoolEntry*>(0x82839700);
+        static auto gameWorldMp = reinterpret_cast<GameWorldMp*>(0x82DFD010);
 
-static auto cgArray = reinterpret_cast<cg_s **>(0x824C5B64);
-static auto clients = reinterpret_cast<clientActive_t **>(0x825A8B6C);
-static auto clientUIActives = reinterpret_cast<clientUIActive_t *>(0x825A5918);
-static auto con = reinterpret_cast<Console *>(0x824DF4A8);
-static auto g_consoleField = reinterpret_cast<field_t *>(0x82502FF8);
-static auto historyEditLines = reinterpret_cast<field_t *>(0x825065B8);
-static auto playerKeys = reinterpret_cast<PlayerKeyState *>(0x82503118);
+        static auto cgArray = reinterpret_cast<cg_s**>(0x824C5B64);
+        static auto clients = reinterpret_cast<clientActive_t**>(0x825A8B6C);
+        static auto clientUIActives = reinterpret_cast<clientUIActive_t*>(0x825A5918);
+        static auto con = reinterpret_cast<Console*>(0x824DF4A8);
+        static auto g_consoleField = reinterpret_cast<field_t*>(0x82502FF8);
+        static auto historyEditLines = reinterpret_cast<field_t*>(0x825065B8);
+        static auto playerKeys = reinterpret_cast<PlayerKeyState*>(0x82503118);
 
-static auto CG_GetPredictedPlayerState = reinterpret_cast<playerState_s *(*)(int localClientNum)>(0x8213DE18);
-static auto CL_CreateNewCommands = reinterpret_cast<void (*)(int localClientNum)>(0x8217E540);
+        static auto CG_GetPredictedPlayerState = reinterpret_cast<playerState_s * (*)(int localClientNum)>(0x8213DE18);
+        static auto CL_CreateNewCommands = reinterpret_cast<void (*)(int localClientNum)>(0x8217E540);
 
-static auto cm = reinterpret_cast<clipMap_t *>(0x83052680);
-static auto fields = reinterpret_cast<client_fields_s *>(0x82027518);
-static auto g_entities = reinterpret_cast<gentity_s *>(0x82E2A580);
-static auto level = reinterpret_cast<level_locals_t *>(0x82FF2F08);
-static auto sharedUiInfo = reinterpret_cast<sharedUiInfo_t *>(0x836A3AC0);
-static auto svsHeader = reinterpret_cast<serverStaticHeader_t *>(0x8367A010);
+        static auto cm = reinterpret_cast<clipMap_t*>(0x83052680);
+        static auto fields = reinterpret_cast<client_fields_s*>(0x82027518);
+        static auto g_entities = reinterpret_cast<gentity_s*>(0x82E2A580);
+        static auto level = reinterpret_cast<level_locals_t*>(0x82FF2F08);
+        static auto sharedUiInfo = reinterpret_cast<sharedUiInfo_t*>(0x836A3AC0);
+        static auto svsHeader = reinterpret_cast<serverStaticHeader_t*>(0x8367A010);
 
-} // namespace mp_tu6
+        // bg_removeBarriers
+        typedef void (*PmoveSingle_t)(pmove_t* pm);
+        static PmoveSingle_t PmoveSingle = reinterpret_cast<PmoveSingle_t>(0x8210B488);
+
+        typedef void (*PM_CheckLadderMove_t)(pmove_t* pm, pml_t* pml);
+        static PM_CheckLadderMove_t PM_CheckLadderMove = reinterpret_cast<PM_CheckLadderMove_t>(0x8210ACC8);
+
+    } // namespace mp_tu6
 } // namespace iw4


### PR DESCRIPTION
# Add barrier clipping removal for IW4 TU6

## Overview

This PR adds an opt-in barrier clipping removal feature for **Call of Duty: Modern Warfare 2 — IW4 TU6**.

The implementation hooks into the TU6 player movement system and modifies the movement trace mask when `bg_removeBarriers` is enabled. This allows player movement to bypass the standard player barrier clipping while retaining the underlying map collision and normal movement systems.

The implementation also adds dedicated ladder handling through `PM_CheckLadderMove` to minimize the impact of the modified trace mask on ladder detection and movement.

Additionally, the TU6 dvar definitions have been updated with the `DVAR_CODINFO` flag:

```cpp
DVAR_CODINFO = 0x08
```

This is required for the new dvar to be properly sent/synchronized to clients, ensuring clients receive and use the correct dvar state.

The feature is disabled by default and can be toggled at runtime through:

```text
bg_removeBarriers 0
bg_removeBarriers 1
```

## What Changed

### Barrier clipping removal

Two TU6 movement collision masks are now explicitly defined:

```cpp
MASK_PLAYER_CLIP  = 0x10000
MASK_BARRIER_CLIP = 0x400
```

When barrier removal is enabled, `PmoveSingle` modifies the movement trace mask by removing `MASK_PLAYER_CLIP` and enabling `MASK_BARRIER_CLIP`.

Conceptually:

```text
Normal movement
    |
    v
pm->tracemask
    |
    +-- PLAYER_CLIP
    +-- BARRIER_CLIP
```

becomes:

```text
Barrier removal enabled
    |
    v
pm->tracemask
    |
    +-- PLAYER_CLIP removed
    +-- BARRIER_CLIP enabled
```

This allows the player to move through collision that would otherwise prevent traversal due to the game's player/barrier clipping.

The implementation operates at the movement trace level rather than modifying map collision data.

### New `bg_removeBarriers` dvar

A new boolean dvar controls the feature:

```text
bg_removeBarriers
```

Default:

```text
false
```

Description:

```text
Remove player collision with out of bound barriers
```

This makes the functionality completely opt-in.

With the dvar disabled, the game uses the normal IW4 TU6 movement behavior.

With the dvar enabled, the modified movement trace mask is used.

### Dvar client synchronization

The new dvar is registered using the `DVAR_CODINFO` flag.

```cpp
DVAR_CODINFO = 0x08
```

This flag is important for the new dvar because `bg_removeBarriers` needs to be properly transmitted/synchronized to clients.

Without the appropriate CODINFO flag, the dvar would not participate in the expected client synchronization behavior.

This ensures that clients receive the correct value of `bg_removeBarriers` and use the corresponding movement behavior rather than relying on an unsynchronized local dvar state.

### `PmoveSingle` hook

A detour has been added for `PmoveSingle`.

When `bg_removeBarriers` is enabled, the hook adjusts `pm->tracemask` before passing execution to the original movement function.

The core operation is:

```cpp
pm->tracemask &= ~MASK_PLAYER_CLIP;
pm->tracemask |= MASK_BARRIER_CLIP;
```

The original `PmoveSingle` implementation is then called normally.

This keeps the actual player movement implementation intact while changing the collision categories considered by its movement traces.

The hook also accounts for ladder state so that the barrier-removal behavior does not unnecessarily interfere with ladder movement.

### `PM_CheckLadderMove` hook

A second detour has been added for `PM_CheckLadderMove`.

This is necessary because changing the movement trace mask globally can affect ladder detection.

During the ladder check, `MASK_PLAYER_CLIP` is temporarily restored:

```cpp
pm->tracemask |= MASK_PLAYER_CLIP;
```

The original ladder movement function is then allowed to execute.

After the ladder check, the movement trace state is restored as appropriate for barrier removal.

This provides the best current balance between:

* Barrier clipping removal
* Normal player movement
* Ladder detection
* Ladder climbing
* Existing collision behavior

The ladder handling is intentionally isolated from the main `PmoveSingle` behavior rather than attempting to disable or bypass the ladder system entirely.

## Dvar Definition

The TU6 dvar flag definitions now include:

```cpp
DVAR_CODINFO = 0x08
```

This allows CODINFO dvars to participate in the engine's client synchronization mechanism.

The resulting behavior is:

```text
Server
  |
  | bg_removeBarriers
  | DVAR_CODINFO
  v
Client synchronization
  |
  v
Client receives correct dvar state
  |
  v
Movement system uses synchronized value
```

This is particularly important for a movement-related dvar because inconsistent server/client dvar state could otherwise result in different collision behavior between the two sides.

## Files Changed

### `src/game/iw4/mp_tu6/components/pm.cpp`

Primary implementation for barrier clipping removal.

Changes include:

* Added `MASK_PLAYER_CLIP`.
* Added `MASK_BARRIER_CLIP`.
* Added `bg_removeBarriers`.
* Added `PmoveSingle` detour/hook.
* Added `PM_CheckLadderMove` detour/hook.
* Added barrier-removal trace-mask manipulation.
* Added ladder-specific trace-mask handling.
* Added installation of both movement detours.
* Added cleanup/removal of both detours.
* Preserved the existing rocket-jump functionality.

The existing TU6 movement functionality remains intact while the new behavior is added as an opt-in feature.

### `src/game/iw4/mp_tu6/symbols.h`

Updated the TU6 symbol definitions required by the new movement hooks.

This provides the engine symbol references necessary to detour:

* `PmoveSingle`
* `PM_CheckLadderMove`

The changes remain isolated to the TU6 symbol set.

### `src/game/iw4/mp_tu6/structs.h`

Updated TU6 definitions required by the new movement/dvar implementation.

The dvar flag definitions now include:

```cpp
DVAR_CODINFO = 0x08
```

This ensures dvars using the CODINFO flag can be correctly represented and synchronized through the existing TU6 dvar system.

## Runtime Behavior

### Disabled

```text
bg_removeBarriers 0
```

Result:

* Normal player clipping.
* Normal barrier collision.
* Normal movement.
* Normal ladder handling.
* No change from existing TU6 behavior.

### Enabled

```text
bg_removeBarriers 1
```

Result:

* Player barrier clipping is removed.
* Normal movement remains functional.
* Underlying map collision remains intact.
* Ladder handling uses the dedicated ladder trace-mask workaround.
* The setting is synchronized through the CODINFO dvar mechanism.

### Toggle behavior

The feature can be toggled without permanently modifying the movement implementation.

```text
bg_removeBarriers 0
        |
        v
Normal collision
        |
        v
bg_removeBarriers 1
        |
        v
Barrier clipping removed
        |
        v
bg_removeBarriers 0
        |
        v
Normal collision restored
```

## Implementation Details

The implementation deliberately modifies `pmove_t::tracemask` rather than attempting to remove or modify collision geometry.

This provides several advantages:

* No map assets need to be modified.
* No collision brushes need to be removed.
* No permanent engine state needs to be changed.
* The feature can be toggled through a dvar.
* The behavior remains localized to player movement.
* Other game systems continue to use their normal collision data.

The original movement functions are still executed through their respective detours, meaning the feature changes the inputs to the movement collision system rather than replacing the movement implementation itself.

## Ladder Handling

Ladder behavior deserves special consideration.

Simply removing `MASK_PLAYER_CLIP` from the movement trace mask can have side effects on ladder detection because ladder interaction is also evaluated through the player movement collision system.

To account for this, `PM_CheckLadderMove` temporarily restores the player clipping bit while the engine performs its ladder check.

This means the implementation effectively has two movement collision modes:

```text
Normal movement:
    PLAYER_CLIP removed
    BARRIER_CLIP enabled

Ladder check:
    PLAYER_CLIP restored
    Original ladder collision behavior
```

After the ladder check has completed, the movement state returns to the appropriate barrier-removal configuration.

This is currently the best available approach for maintaining ladder functionality while still providing barrier clipping removal.

## Testing

The implementation has been tested **in-game on IW4 TU6**.

### Barrier removal

Confirmed working:

* `bg_removeBarriers 1` successfully removes the intended barrier clipping.
* Players can traverse areas previously restricted by the relevant barrier collision.
* The feature behaves as intended when enabled.

### Toggle behavior

Confirmed working:

* Feature enabled with `bg_removeBarriers`.
* Feature disabled again with the dvar.
* Collision behavior correctly changes when toggled.
* Re-enabling the feature restores barrier removal.

### Player movement

Confirmed working:

* Standard player movement remains functional.
* Movement behavior remains stable with barrier removal enabled.
* No significant regressions were observed in normal movement.

### Ladder handling

Confirmed working to the extent currently possible with the movement-mask approach.

* Ladder detection remains functional.
* Ladder movement remains usable.
* The dedicated `PM_CheckLadderMove` handling prevents the barrier-removal trace-mask change from completely interfering with ladder behavior.

The ladder implementation represents the best current handling available without introducing substantially more invasive changes to the movement system.

### Client synchronization

The new dvar is registered using:

```cpp
DVAR_CODINFO = 0x08
```

This ensures the dvar participates in the appropriate CODINFO synchronization mechanism so clients receive the correct `bg_removeBarriers` state.

## Compatibility

The implementation is isolated to:

```text
src/game/iw4/mp_tu6/
```

and therefore specifically targets:

**IW4 Multiplayer TU6**

It does not alter TU9 or other game implementations.

The feature is also disabled by default, ensuring existing TU6 behavior remains unchanged unless explicitly enabled.

## Regression Testing

The following existing functionality was verified during in-game testing:

* Normal movement
* Barrier collision toggle
* Barrier removal
* Dvar enable/disable behavior
* Ladder detection
* Ladder movement
* Existing movement behavior
* Existing rocket-jump functionality

No movement regressions were observed during testing.

## Summary

This PR adds an opt-in barrier clipping removal system to **IW4 TU6** by modifying the player movement trace mask through `PmoveSingle`.

The implementation:

* Adds `bg_removeBarriers`.
* Removes `MASK_PLAYER_CLIP` when enabled.
* Enables `MASK_BARRIER_CLIP`.
* Adds dedicated `PM_CheckLadderMove` handling.
* Adds the required TU6 movement symbols/structures.
* Adds `DVAR_CODINFO = 0x08`.
* Ensures the new dvar is properly synchronized to clients.
* Preserves normal movement when disabled.
* Has been tested in-game with the feature both enabled and disabled.

Overall, this provides a clean, runtime-controlled method of removing IW4 TU6 barrier clipping without modifying map collision data or introducing a full noclip-style movement system.
