### PR TITLE
Iw4 tu6 barrier clipping dvar

### DIFF
--- a/src/game/iw4/mp_tu6/components/pm.cpp
+++ b/src/game/iw4/mp_tu6/components/pm.cpp
@@ -1,6 +1,10 @@
 #include "pch.h"
 #include "pm.h"
 
+// bg_removeBarriers
+int MASK_PLAYER_CLIP = 0x10000;
+int MASK_BARRIER_CLIP = 0x400;
+
 namespace iw4
 {
 namespace mp_tu6
@@ -9,8 +13,11 @@ namespace
 {
 dvar_t *bg_rocketJump = nullptr;
 dvar_t *bg_rocketJumpScale = nullptr;
+dvar_t *bg_removeBarriers = nullptr; // bg_removeBarriers
 
 Detour Weapon_RocketLauncher_Fire_Detour;
+Detour PmoveSingle_Detour; // bg_removeBarriers
+Detour PM_CheckLadderMove_Detour; // bg_removeBarriers
 
 gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, unsigned int weaponIndex, double spread, weaponParms *wp,
                                            weaponParms *gunVel, lockonFireParms *lockParms,
@@ -30,6 +37,38 @@ gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, unsigned int weaponIn
     return result;
 }
 
+// bg_removeBarriers
+void PmoveSingle_Hook(pmove_t* pm)
+{
+    if (bg_removeBarriers && bg_removeBarriers->current.enabled)
+    {
+        if (pm != nullptr && (pm->ps->pm_flags & PMF_LADDER) == 0)
+        {
+            pm->tracemask &= ~MASK_PLAYER_CLIP;
+            pm->tracemask |= MASK_BARRIER_CLIP;
+        }
+    }
+
+    PmoveSingle_Detour.GetOriginal<decltype(PmoveSingle)>()(pm);
+}
+
+void PM_CheckLadderMove_Hook(pmove_t* pm, pml_t* pml)
+{
+    const auto fix_ladder_movement = (bg_removeBarriers && bg_removeBarriers->current.enabled && pm != nullptr);
+
+    if (fix_ladder_movement)
+    {
+        pm->tracemask |= MASK_PLAYER_CLIP;
+    }
+
+    PM_CheckLadderMove_Detour.GetOriginal<decltype(PM_CheckLadderMove)>()(pm, pml);
+
+    if (fix_ladder_movement && (pm->ps->pm_flags & PMF_LADDER) == 0)
+    {
+        pm->tracemask &= ~MASK_PLAYER_CLIP;
+    }
+}
+
 } // namespace
 
 void pm::OnDvarInit()
@@ -37,17 +76,28 @@ void pm::OnDvarInit()
     bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
     bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
                                             "The scale applied to the pushback force of a rocket");
+    // bg_removeBarriers
+    bg_removeBarriers = Dvar_RegisterBool("bg_removeBarriers", false, DVAR_CODINFO, "Remove player collision with out of bound barriers");
 }
 
 pm::pm()
 {
     Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
     Weapon_RocketLauncher_Fire_Detour.Install();
+    // bg_removeBarriers
+    PmoveSingle_Detour = Detour(PmoveSingle, PmoveSingle_Hook);
+    PmoveSingle_Detour.Install();
+
+    PM_CheckLadderMove_Detour = Detour(PM_CheckLadderMove, PM_CheckLadderMove_Hook);
+    PM_CheckLadderMove_Detour.Install();
 }
 
 pm::~pm()
 {
     Weapon_RocketLauncher_Fire_Detour.Remove();
+    // bg_removeBarriers
+    PmoveSingle_Detour.Remove();
+    PM_CheckLadderMove_Detour.Remove();
 }
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/structs.h
+++ b/src/game/iw4/mp_tu6/structs.h
@@ -128,6 +128,7 @@ union DvarLimits
 
 enum DvarFlags : std::uint16_t
 {
+    DVAR_CODINFO = 0x08, // needed to properly send to clients as a dvar
     DVAR_FLAG_SERVERINFO = 0x10,
 };
 
@@ -2116,6 +2117,100 @@ union XAssetEntryPoolEntry
 static_assert(sizeof(XAssetEntry) == 0x10, "");
 static_assert(offsetof(XAssetEntry, nextHash) == 0xC, "");
 static_assert(offsetof(XAssetEntry, nextOverride) == 0xE, "");
+
+// bg_removeBarriers - some items like PMF are ripped from iw4x.
+enum
+{
+    PMF_PRONE = 1 << 0,
+    PMF_DUCKED = 1 << 1,
+    PMF_MANTLE = 1 << 2,
+    PMF_LADDER = 1 << 3,
+    PMF_SIGHT_AIMING = 1 << 4,
+    PMF_BACKWARDS_RUN = 1 << 5,
+    PMF_WALKING = 1 << 6,
+    PMF_TIME_HARDLANDING = 1 << 7,
+    PMF_TIME_KNOCKBACK = 1 << 8,
+    PMF_PRONEMOVE_OVERRIDDEN = 1 << 9,
+    PMF_RESPAWNED = 1 << 10,
+    PMF_FROZEN = 1 << 11,
+    PMF_LADDER_FALL = 1 << 12,
+    PMF_JUMPING = 1 << 13,
+    PMF_SPRINTING = 1 << 14,
+    PMF_SHELLSHOCKED = 1 << 15,
+    PMF_MELEE_CHARGE = 1 << 16,
+    PMF_NO_SPRINT = 1 << 17,
+    PMF_NO_JUMP = 1 << 18,
+    PMF_REMOTE_CONTROLLING = 1 << 19,
+    PMF_ANIM_SCRIPTED = 1 << 20,
+    PMF_UNK1 = 1 << 21,
+    PMF_DIVING = 1 << 22,
+};
+
+enum TraceHitType : __int32
+{
+    TRACE_HITTYPE_NONE = 0x0,
+    TRACE_HITTYPE_ENTITY = 0x1,
+    TRACE_HITTYPE_DYNENT_MODEL = 0x2,
+    TRACE_HITTYPE_DYNENT_BRUSH = 0x3,
+    TRACE_HITTYPE_GLASS = 0x4,
+};
+
+struct __declspec(align(4)) trace_t
+{
+    float fraction;
+    float normal[3];
+    int surfaceFlags;
+    int contents;
+    const char* material;
+    TraceHitType hitType;
+    unsigned __int16 hitId;
+    float fractionForHitType;
+    unsigned __int16 modelIndex;
+    unsigned __int16 partName;
+    unsigned __int16 partGroup;
+    bool allsolid;
+    bool startsolid;
+    bool walkable;
+};
+
+struct pml_t
+{
+    float forward[3];
+    float right[3];
+    float up[3];
+    float frametime;
+    int msec;
+    int walking;
+    int groundPlane;
+    int almostGroundPlane;
+    trace_t groundTrace;
+    float impactSpeed;
+    float previous_origin[3];
+    float previous_velocity[3];
+    unsigned int holdrand;
+};
+
+struct pmove_t
+{
+    playerState_s* ps;
+    usercmd_s cmd;
+    usercmd_s oldcmd;
+    int tracemask;
+    int numtouch;
+    int touchents[32];
+    Bounds bounds;
+    float xyspeed;
+    int proneChange;
+    float maxSprintTimeMultiplier;
+    bool mantleStarted;
+    float mantleEndPos[3];
+    int mantleDuration;
+    int viewChangeTime;
+    float viewChange;
+    float fTorsoPitch;
+    float fWaistPitch;
+    unsigned __int8 handler;
+};
 
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/symbols.h
+++ b/src/game/iw4/mp_tu6/symbols.h
@@ -292,6 +292,13 @@ static auto UI_DrawText =
 
 static auto va = reinterpret_cast<char *(*)(const char *format, ...)>(0x823160A8);
 
+// bg_removeBarriers
+typedef void (*PmoveSingle_t)(pmove_t* pm);
+static PmoveSingle_t PmoveSingle = reinterpret_cast<PmoveSingle_t>(0x8210B488);
+
+typedef void (*PM_CheckLadderMove_t)(pmove_t* pm, pml_t* pml);
+static PM_CheckLadderMove_t PM_CheckLadderMove = reinterpret_cast<PM_CheckLadderMove_t>(0x8210ACC8);
+
 // Data
 static auto DB_XAssetPool = reinterpret_cast<void **>(0x82442828);
 static auto g_assetNames = reinterpret_cast<const char **>(0x82442298);


### PR DESCRIPTION
# IW4 TU6: Add map barrier clipping removal

## Summary

Adds an optional `bg_removeBarriers` dvar to IW4 TU6 that allows players to clip through map barriers.

* `bg_removeBarriers 0` — normal map barrier behavior.
* `bg_removeBarriers 1` — removes the relevant barrier collision from player movement, allowing access to areas normally blocked by map barriers, including rooftops and other restricted areas.
* The feature is disabled by default.

This is implemented through the player movement trace mask and does not modify map collision data.

## Implementation

The movement code now defines:

```cpp
MASK_PLAYER_CLIP  = 0x10000
MASK_BARRIER_CLIP = 0x400
```

When `bg_removeBarriers` is enabled, `PmoveSingle` changes `pm->tracemask` to remove `MASK_PLAYER_CLIP` and add `MASK_BARRIER_CLIP`.

```cpp
pm->tracemask &= ~MASK_PLAYER_CLIP;
pm->tracemask |= MASK_BARRIER_CLIP;
```

The normal `PmoveSingle` implementation is still called, so this only changes the collision mask used by player movement.

### Ladder handling

Removing player clipping affects ladder checks, so `PM_CheckLadderMove` is handled separately and temporarily restores `MASK_PLAYER_CLIP` while the ladder check runs.

Ladder behavior is **not 100% preserved with `bg_removeBarriers` enabled**. There are still some limitations due to how the movement and collision system handles the modified trace mask, but the current implementation provides the best ladder behavior possible with this approach without making the change significantly more invasive.

## Dvar Synchronization

Adds:

```cpp
DVAR_CODINFO = 0x08
```

This is required for `bg_removeBarriers` to be handled as a CODINFO dvar and properly synchronized to clients, ensuring clients receive and use the correct dvar state.

## Files Changed

### `src/game/iw4/mp_tu6/components/pm.cpp`

* Added `bg_removeBarriers`.
* Added player/barrier collision masks.
* Added `PmoveSingle` hook for barrier removal.
* Added `PM_CheckLadderMove` hook for ladder handling.
* Added detour installation and cleanup.
* Existing movement and rocket-jump functionality remains intact.

### `src/game/iw4/mp_tu6/symbols.h`

* Added the TU6 symbols required for `PmoveSingle` and `PM_CheckLadderMove` hooks.

### `src/game/iw4/mp_tu6/structs.h`

* Added the required TU6 definitions, including `DVAR_CODINFO = 0x08`.

## Testing

Tested in-game on IW4 TU6.

Verified:

* Barrier removal works with `bg_removeBarriers 1`.
* Normal barrier behavior is restored with `bg_removeBarriers 0`.
* Players can access areas normally blocked by map barriers, including rooftops.
* Toggling the dvar works as expected.
* Normal player movement remains functional.
* Ladder functionality remains usable, although it is not fully preserved while barrier removal is enabled.
* Existing movement functionality, including rocket jumping, remains intact.

## Scope

This change is limited to **IW4 Multiplayer TU6** and is disabled by default.

No map assets or collision geometry are modified.
